### PR TITLE
Fix concurrency issue in gemini-cli workflow

### DIFF
--- a/.github/workflows/gemini-cli.yml
+++ b/.github/workflows/gemini-cli.yml
@@ -12,7 +12,7 @@ on:
       - 'created'
 
 concurrency:
-  group: '${{ github.workflow }}-${{ github.head_ref || github.ref || github.event.issue.number }}'
+  group: '${{ github.workflow }}-${{ github.event.issue.number }}'
   cancel-in-progress: true
 
 defaults:

--- a/workflows/gemini-cli/gemini-cli.yml
+++ b/workflows/gemini-cli/gemini-cli.yml
@@ -12,7 +12,7 @@ on:
       - 'created'
 
 concurrency:
-  group: '${{ github.workflow }}-${{ github.head_ref || github.ref || github.event.issue.number }}'
+  group: '${{ github.workflow }}-${{ github.event.issue.number }}'
   cancel-in-progress: true
 
 defaults:


### PR DESCRIPTION
This PR addresses a concurrency issue in the `gemini-cli` workflow that could cause multiple workflow to be canceled when comments from the same branch/repo triggered the gemini-cli workflow. 

The previous concurrency key was too broad, using `github.head_ref` or `github.ref`, which are not always relevant in the context of an `issue_comment` event. 

The fix simplifies the concurrency group to be solely based on the issue number:
```yaml
concurrency:
  group: '${{ github.workflow }}-${{ github.event.issue.number }}'
  cancel-in-progress: true
```

This ensures that only one instance of the workflow runs per issue at any given time, correctly canceling any in-progress runs when a new comment is created or an existing one is edited.