### PR TITLE
refactor: rename `settings_json` to `settings`

### DIFF
--- a/.github/workflows/gemini-cli.yml
+++ b/.github/workflows/gemini-cli.yml
@@ -180,7 +180,7 @@ jobs:
           GOOGLE_CLOUD_LOCATION: '${{ vars.GOOGLE_CLOUD_LOCATION }}'
           GOOGLE_GENAI_USE_VERTEXAI: '${{ vars.GOOGLE_GENAI_USE_VERTEXAI }}'
         with:
-          settings_json: |
+          settings: |
             {
               "coreTools": [
                 "run_shell_command(echo)",

--- a/.github/workflows/gemini-issue-automated-triage.yml
+++ b/.github/workflows/gemini-issue-automated-triage.yml
@@ -71,7 +71,7 @@ jobs:
           GOOGLE_CLOUD_LOCATION: '${{ vars.GOOGLE_CLOUD_LOCATION }}'
           GOOGLE_GENAI_USE_VERTEXAI: '${{ vars.GOOGLE_GENAI_USE_VERTEXAI }}'
         with:
-          settings_json: |-
+          settings: |-
             {
               "coreTools": [
                 "run_shell_command(gh label list)",

--- a/.github/workflows/gemini-issue-scheduled-triage.yml
+++ b/.github/workflows/gemini-issue-scheduled-triage.yml
@@ -79,7 +79,7 @@ jobs:
           GOOGLE_CLOUD_LOCATION: '${{ vars.GOOGLE_CLOUD_LOCATION }}'
           GOOGLE_GENAI_USE_VERTEXAI: '${{ vars.GOOGLE_GENAI_USE_VERTEXAI }}'
         with:
-          settings_json: |-
+          settings: |-
             {
               "coreTools": [
                 "run_shell_command(echo)",

--- a/.github/workflows/gemini-pr-review.yml
+++ b/.github/workflows/gemini-pr-review.yml
@@ -158,7 +158,7 @@ jobs:
           GOOGLE_CLOUD_LOCATION: '${{ vars.GOOGLE_CLOUD_LOCATION }}'
           GOOGLE_GENAI_USE_VERTEXAI: '${{ vars.GOOGLE_GENAI_USE_VERTEXAI }}'
         with:
-          settings_json: |-
+          settings: |-
             {
               "coreTools": [
                 "run_shell_command(echo)",

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ environment variables, and secrets.
 
 -   <a name="prompt"></a><a href="#user-content-prompt"><code>prompt</code></a>: _(Optional, default: `You are a helpful assistant.`)_ A specific prompt to guide Gemini.
 
--   <a name="settings_json"></a><a href="#user-content-settings_json"><code>settings_json</code></a>: _(Optional)_ A JSON string to configure the Gemini CLI. This will be written to
+-   <a name="settings"></a><a href="#user-content-settings"><code>settings</code></a>: _(Optional)_ A JSON string to configure the Gemini CLI. This will be written to
     .gemini/settings.json.
 
 

--- a/action.yml
+++ b/action.yml
@@ -22,7 +22,7 @@ inputs:
     description: 'A specific prompt to guide Gemini.'
     required: false
     default: 'You are a helpful assistant.'
-  settings_json:
+  settings:
     description: |
       A JSON string to configure the Gemini CLI. This will be written to
       .gemini/settings.json.
@@ -38,13 +38,13 @@ runs:
   steps:
     - name: 'Configure Gemini CLI'
       if: |-
-        ${{ inputs.settings_json != '' }}
+        ${{ inputs.settings != '' }}
       run: |
         mkdir -p .gemini/
-        echo "${SETTINGS_JSON}" > ".gemini/settings.json"
+        echo "${SETTINGS}" > ".gemini/settings.json"
       shell: 'bash'
       env:
-        SETTINGS_JSON: '${{ inputs.settings_json }}'
+        SETTINGS: '${{ inputs.settings }}'
 
     - name: 'Authenticate to Google Cloud for Telemetry'
       if: |-

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -62,7 +62,7 @@ After running the setup script, configure your GitHub Actions workflow with the 
     GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
   with:
     # Enable telemetry in settings
-    settings_json: |
+    settings: |
       {
         "telemetry": {
           "enabled": true,
@@ -73,7 +73,7 @@ After running the setup script, configure your GitHub Actions workflow with the 
     # ... other inputs ...
 ```
 
-**Important**: To enable telemetry, you must include the `settings_json` configuration as shown above. This tells the Gemini CLI to:
+**Important**: To enable telemetry, you must include the `settings` configuration as shown above. This tells the Gemini CLI to:
 - Enable telemetry collection
 - Send data to the local OpenTelemetry collector (which forwards to GCP)
 - Disable sandbox mode (required for telemetry)

--- a/workflows/gemini-cli/README.md
+++ b/workflows/gemini-cli/README.md
@@ -137,7 +137,7 @@ The most powerful feature is the ability to define the tools the AI can use. In 
 **Example: Adding the `ls` command**
 ```yaml
 with:
-  settings_json: |
+  settings: |
     {
       "coreTools": [
         "run_shell_command(ls)",

--- a/workflows/gemini-cli/gemini-cli.yml
+++ b/workflows/gemini-cli/gemini-cli.yml
@@ -180,7 +180,7 @@ jobs:
           GOOGLE_CLOUD_LOCATION: '${{ vars.GOOGLE_CLOUD_LOCATION }}'
           GOOGLE_GENAI_USE_VERTEXAI: '${{ vars.GOOGLE_GENAI_USE_VERTEXAI }}'
         with:
-          settings_json: |
+          settings: |
             {
               "coreTools": [
                 "run_shell_command(echo)",

--- a/workflows/issue-triage/gemini-issue-automated-triage.yml
+++ b/workflows/issue-triage/gemini-issue-automated-triage.yml
@@ -71,7 +71,7 @@ jobs:
           GOOGLE_CLOUD_LOCATION: '${{ vars.GOOGLE_CLOUD_LOCATION }}'
           GOOGLE_GENAI_USE_VERTEXAI: '${{ vars.GOOGLE_GENAI_USE_VERTEXAI }}'
         with:
-          settings_json: |-
+          settings: |-
             {
               "coreTools": [
                 "run_shell_command(gh label list)",

--- a/workflows/issue-triage/gemini-issue-scheduled-triage.yml
+++ b/workflows/issue-triage/gemini-issue-scheduled-triage.yml
@@ -79,7 +79,7 @@ jobs:
           GOOGLE_CLOUD_LOCATION: '${{ vars.GOOGLE_CLOUD_LOCATION }}'
           GOOGLE_GENAI_USE_VERTEXAI: '${{ vars.GOOGLE_GENAI_USE_VERTEXAI }}'
         with:
-          settings_json: |-
+          settings: |-
             {
               "coreTools": [
                 "run_shell_command(echo)",

--- a/workflows/pr-review/gemini-pr-review.yml
+++ b/workflows/pr-review/gemini-pr-review.yml
@@ -159,7 +159,7 @@ jobs:
           GOOGLE_CLOUD_LOCATION: '${{ vars.GOOGLE_CLOUD_LOCATION }}'
           GOOGLE_GENAI_USE_VERTEXAI: '${{ vars.GOOGLE_GENAI_USE_VERTEXAI }}'
         with:
-          settings_json: |-
+          settings: |-
             {
               "coreTools": [
                 "run_shell_command(echo)",


### PR DESCRIPTION
The input name `settings_json` is unnecessarily verbose. Renaming it to `settings` makes the action's interface cleaner and more intuitive. The input's description clearly states that it expects a JSON string, making the `_json` suffix redundant.
