### PR TITLE
fix(otel): Configure collector and set credential permissions

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -67,11 +67,13 @@ runs:
         mkdir -p .gemini/
         sed "s/OTLP_GOOGLE_CLOUD_PROJECT/${OTLP_GOOGLE_CLOUD_PROJECT}/g" "${GITHUB_ACTION_PATH}/scripts/collector-gcp.yaml.template" > ".gemini/collector-gcp.yaml"
 
+        chmod 444 "$GOOGLE_APPLICATION_CREDENTIALS"
         docker run -d --name gemini-telemetry-collector --network host \
           -v "${GITHUB_WORKSPACE}:/github/workspace" \
           -e "GOOGLE_APPLICATION_CREDENTIALS=${GOOGLE_APPLICATION_CREDENTIALS/$GITHUB_WORKSPACE//github/workspace}" \
           -w "/github/workspace" \
-          otel/opentelemetry-collector-contrib:0.128.0
+          otel/opentelemetry-collector-contrib:0.128.0 \
+          --config /github/workspace/.gemini/collector-gcp.yaml
 
     - name: 'Install Gemini CLI'
       id: 'install'

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -11,12 +11,13 @@ The action uses its own built-in telemetry system that ensures consistent and re
   - [Advanced Setup](#advanced-setup)
   - [GitHub Actions Configuration](#github-actions-configuration)
   - [Viewing Telemetry Data](#viewing-telemetry-data)
+  - [Collector Configuration](#collector-configuration)
   - [Troubleshooting](#troubleshooting)
 
 
 ## Required Environment Variables
 
-For a complete list of required environment variables, their descriptions, and how to configure them, see [Configuration](./configuration.md#environment-variables).
+For a complete list of required environment variables, their descriptions, and how to configure them, see [docs](../README.md#environment-variables).
 
 When enabled, the action will automatically start an OpenTelemetry collector that forwards traces, metrics, and logs to your specified GCP project. You can then use Google Cloud's operations suite (formerly Stackdriver) to visualize and analyze this data.
 
@@ -79,6 +80,14 @@ Once configured, you can view your telemetry data in the Google Cloud Console:
 - **Traces**: [Cloud Trace Console](https://console.cloud.google.com/traces)
 - **Metrics**: [Cloud Monitoring Console](https://console.cloud.google.com/monitoring)
 - **Logs**: [Cloud Logging Console](https://console.cloud.google.com/logs)
+
+## Collector Configuration
+
+The action automatically handles the setup of the OpenTelemetry (OTel) collector. 
+This includes generating the necessary Google Cloud configuration, setting the correct
+file permissions for credentials, and running the collector in a Docker container. The
+collector is configured to use only the `googlecloud` exporter, ensuring telemetry
+is sent directly to your Google Cloud project. 
 
 ## Troubleshooting
 

--- a/scripts/collector-gcp.yaml.template
+++ b/scripts/collector-gcp.yaml.template
@@ -13,10 +13,6 @@ exporters:
       prefix: 'custom.googleapis.com/gemini_cli'
     log:
       default_log_name: 'gemini_cli'
-  debug:
-    verbosity: 'detailed'
-    sampling_initial: '2'
-    sampling_thereafter: '500'
 service:
   telemetry:
     logs:
@@ -27,12 +23,12 @@ service:
     traces:
       receivers: ['otlp']
       processors: ['batch']
-      exporters: ['googlecloud', 'debug']
+      exporters: ['googlecloud']
     metrics:
       receivers: ['otlp']
       processors: ['batch']
-      exporters: ['googlecloud', 'debug']
+      exporters: ['googlecloud']
     logs:
       receivers: ['otlp']
       processors: ['batch']
-      exporters: ['googlecloud', 'debug']
+      exporters: ['googlecloud']


### PR DESCRIPTION
This change introduces two main fixes for the OpenTelemetry collector setup:

1.  **Collector Configuration:** The `docker run` command for the collector now includes the `--config` flag to properly load the generated GCP configuration. The `debug` exporter has been removed from the service pipelines, leaving only the `googlecloud` exporter for a cleaner and more focused setup.

2.  **Credential Permissions:** The script now sets read-only permissions (`444`) on the `GOOGLE_APPLICATION_CREDENTIALS` file. This ensures the Docker container can access the credentials while adhering to the principle of least privilege.
