### PR TITLE
docs(workflows): update examples to include GCA auth

### DIFF
--- a/workflows/gemini-cli/gemini-cli.yml
+++ b/workflows/gemini-cli/gemini-cli.yml
@@ -179,6 +179,8 @@ jobs:
           GOOGLE_CLOUD_PROJECT: '${{ vars.GOOGLE_CLOUD_PROJECT }}'
           GOOGLE_CLOUD_LOCATION: '${{ vars.GOOGLE_CLOUD_LOCATION }}'
           GOOGLE_GENAI_USE_VERTEXAI: '${{ vars.GOOGLE_GENAI_USE_VERTEXAI }}'
+          GOOGLE_GENAI_USE_GCA: '${{ vars.GOOGLE_GENAI_USE_GCA }}'
+          SERVICE_ACCOUNT_EMAIL: '${{ vars.SERVICE_ACCOUNT_EMAIL }}'
         with:
           settings: |
             {

--- a/workflows/issue-triage/gemini-issue-automated-triage.yml
+++ b/workflows/issue-triage/gemini-issue-automated-triage.yml
@@ -70,6 +70,8 @@ jobs:
           GOOGLE_CLOUD_PROJECT: '${{ vars.GOOGLE_CLOUD_PROJECT }}'
           GOOGLE_CLOUD_LOCATION: '${{ vars.GOOGLE_CLOUD_LOCATION }}'
           GOOGLE_GENAI_USE_VERTEXAI: '${{ vars.GOOGLE_GENAI_USE_VERTEXAI }}'
+          GOOGLE_GENAI_USE_GCA: '${{ vars.GOOGLE_GENAI_USE_GCA }}'
+          SERVICE_ACCOUNT_EMAIL: '${{ vars.SERVICE_ACCOUNT_EMAIL }}'
         with:
           settings: |-
             {

--- a/workflows/issue-triage/gemini-issue-scheduled-triage.yml
+++ b/workflows/issue-triage/gemini-issue-scheduled-triage.yml
@@ -78,6 +78,8 @@ jobs:
           GOOGLE_CLOUD_PROJECT: '${{ vars.GOOGLE_CLOUD_PROJECT }}'
           GOOGLE_CLOUD_LOCATION: '${{ vars.GOOGLE_CLOUD_LOCATION }}'
           GOOGLE_GENAI_USE_VERTEXAI: '${{ vars.GOOGLE_GENAI_USE_VERTEXAI }}'
+          GOOGLE_GENAI_USE_GCA: '${{ vars.GOOGLE_GENAI_USE_GCA }}'
+          SERVICE_ACCOUNT_EMAIL: '${{ vars.SERVICE_ACCOUNT_EMAIL }}'
         with:
           settings: |-
             {

--- a/workflows/pr-review/gemini-pr-review.yml
+++ b/workflows/pr-review/gemini-pr-review.yml
@@ -158,6 +158,8 @@ jobs:
           GOOGLE_CLOUD_PROJECT: '${{ vars.GOOGLE_CLOUD_PROJECT }}'
           GOOGLE_CLOUD_LOCATION: '${{ vars.GOOGLE_CLOUD_LOCATION }}'
           GOOGLE_GENAI_USE_VERTEXAI: '${{ vars.GOOGLE_GENAI_USE_VERTEXAI }}'
+          GOOGLE_GENAI_USE_GCA: '${{ vars.GOOGLE_GENAI_USE_GCA }}'
+          SERVICE_ACCOUNT_EMAIL: '${{ vars.SERVICE_ACCOUNT_EMAIL }}'
         with:
           settings: |-
             {


### PR DESCRIPTION
The example workflows for the CLI, issue triage, and PR review have been updated to include the necessary environment variables for authenticating with Gemini Code Assist ( and ).

This makes the examples consistent with the new GCA authentication feature.

