### PR TITLE
feat: Add Issue Deduplication Workflow

### DIFF
--- a/.github/workflows/gemini-issue-automated-triage.yml
+++ b/.github/workflows/gemini-issue-automated-triage.yml
@@ -138,18 +138,20 @@ jobs:
           app-id: '${{ vars.APP_ID }}'
           private-key: '${{ secrets.APP_PRIVATE_KEY }}'
 
-      - id: 'auth'
+      - name: 'Authenticate to Google Cloud'
+        id: 'auth'
         uses: 'google-github-actions/auth@140bb5113ffb6b65a7e9b937a81fa96cf5064462' # ratchet:google-github-actions/auth@v2
         with:
+          token_format: 'access_token'
           workload_identity_provider: '${{ vars.GCP_WIF_PROVIDER }}'
           service_account: '${{ vars.SERVICE_ACCOUNT_EMAIL }}'
 
-      - name: 'Set up Cloud SDK'
-        uses: 'google-github-actions/setup-gcloud@6189d56e4096ee891640bb02ac264be376592d6a' # ratchet:google-github-actions/setup-gcloud@v2
-
-      - name: 'Configure Docker for Artifact Registry'
-        run: |-
-          gcloud auth configure-docker northamerica-northeast1-docker.pkg.dev
+      - name: 'Login to GAR'
+        uses: 'docker/login-action@v3'
+        with:
+          registry: 'northamerica-northeast1-docker.pkg.dev'
+          username: 'oauth2accesstoken'
+          password: '${{ steps.auth.outputs.access_token }}'
 
       - name: 'Download AlloyDB Auth Proxy'
         run: |

--- a/.github/workflows/gemini-issue-automated-triage.yml
+++ b/.github/workflows/gemini-issue-automated-triage.yml
@@ -173,8 +173,6 @@ jobs:
           GITHUB_TOKEN: '${{ steps.generate_token.outputs.token || secrets.GITHUB_TOKEN }}'
           ISSUE_NUMBER: '${{ github.event.issue.number }}'
           REPOSITORY: '${{ github.repository }}'
-          REPO_OWNER: '${{ github.repository_owner }}'
-          REPO_NAME: '${{ github.event.repository.name }}'
           GEMINI_CLI_VERSION: '${{ vars.GEMINI_CLI_VERSION }}'
           OTLP_GOOGLE_CLOUD_PROJECT: '${{ vars.OTLP_GOOGLE_CLOUD_PROJECT }}'
           GCP_WIF_PROVIDER: '${{ vars.GCP_WIF_PROVIDER }}'
@@ -243,8 +241,8 @@ jobs:
             ## Steps
 
             1.  **Find Potential Duplicates:**
-                - The repo_owner/repo_name is ${{ github.repository }} and the issue number is ${{ github.event.issue.number }}.
-                - Use the `duplicates` tool with the `repo_owner`, `repo_name`, and `issue_number` to find potential duplicates for the current issue. Do not use the `threshold` parameter.
+                - The repository is ${{ github.repository }} and the issue number is ${{ github.event.issue.number }}.
+                - Use the `duplicates` tool with the `repo` and `issue_number` to find potential duplicates for the current issue. Do not use the `threshold` parameter.
                 - If no duplicates are found, you are done.
 
             2.  **Refine Duplicates List (if necessary):**

--- a/.github/workflows/gemini-issue-automated-triage.yml
+++ b/.github/workflows/gemini-issue-automated-triage.yml
@@ -116,13 +116,14 @@ jobs:
 
   deduplicate-issues:
     if: >
-      github.event_name == 'issues' ||
+      vars.ALLOYDB_INSTANCE_CONNECTION_NAME &&
+      (github.event_name == 'issues' ||
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'issue_comment' &&
        contains(github.event.comment.body, '@gemini-cli /deduplicate') &&
        (github.event.comment.author_association == 'OWNER' ||
         github.event.comment.author_association == 'MEMBER' ||
-        github.event.comment.author_association == 'COLLABORATOR'))
+        github.event.comment.author_association == 'COLLABORATOR')))
     timeout-minutes: 10
     runs-on: 'ubuntu-latest'
 

--- a/.github/workflows/gemini-issue-automated-triage.yml
+++ b/.github/workflows/gemini-issue-automated-triage.yml
@@ -141,16 +141,17 @@ jobs:
           private-key: '${{ secrets.APP_PRIVATE_KEY }}'
 
       - id: 'auth'
-        uses: 'google-github-actions/auth@v2'
+        uses: 'google-github-actions/auth@140bb5113ffb6b65a7e9b937a81fa96cf5064462' # ratchet:google-github-actions/auth@v2
         with:
           workload_identity_provider: '${{ vars.GCP_WIF_PROVIDER }}'
           service_account: '${{ vars.SERVICE_ACCOUNT_EMAIL }}'
 
       - name: 'Set up Cloud SDK'
-        uses: 'google-github-actions/setup-gcloud@v2'
+        uses: 'google-github-actions/setup-gcloud@6189d56e4096ee891640bb02ac264be376592d6a' # ratchet:google-github-actions/setup-gcloud@v2
 
       - name: 'Configure Docker for Artifact Registry'
-        run: gcloud auth configure-docker northamerica-northeast1-docker.pkg.dev
+        run: |-
+          gcloud auth configure-docker northamerica-northeast1-docker.pkg.dev
 
       - name: 'Download AlloyDB Auth Proxy'
         run: |
@@ -158,7 +159,8 @@ jobs:
           chmod +x alloydb-auth-proxy
 
       - name: 'Start AlloyDB Auth Proxy'
-        run: ./alloydb-auth-proxy "${{ vars.ALLOYDB_INSTANCE_CONNECTION_NAME }}" --public-ip -i --impersonate-service-account ${{ vars.SERVICE_ACCOUNT_EMAIL }} &
+        run: |-
+          ./alloydb-auth-proxy "${{ vars.ALLOYDB_INSTANCE_CONNECTION_NAME }}" --public-ip -i --impersonate-service-account ${{ vars.SERVICE_ACCOUNT_EMAIL }} &
 
       - name: 'Test AlloyDB Auth Proxy'
         env:

--- a/.github/workflows/gemini-issue-automated-triage.yml
+++ b/.github/workflows/gemini-issue-automated-triage.yml
@@ -48,7 +48,8 @@ jobs:
 
       - name: 'Generate GitHub App Token'
         id: 'generate_token'
-        if: vars.APP_ID != ''
+        if: |-
+          ${{ vars.APP_ID != '' }}
         uses: 'actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e' # ratchet:actions/create-github-app-token@v2
         with:
           app-id: '${{ vars.APP_ID }}'
@@ -132,7 +133,8 @@ jobs:
 
       - name: 'Generate GitHub App Token'
         id: 'generate_token'
-        if: vars.APP_ID != ''
+        if: |-
+          ${{ vars.APP_ID  != '' }}
         uses: 'actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e' # ratchet:actions/create-github-app-token@v2
         with:
           app-id: '${{ vars.APP_ID }}'
@@ -147,7 +149,7 @@ jobs:
           service_account: '${{ vars.SERVICE_ACCOUNT_EMAIL }}'
 
       - name: 'Login to GAR'
-        uses: 'docker/login-action@v3'
+        uses: 'docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772' # ratchet:docker/login-action@v3
         with:
           registry: 'northamerica-northeast1-docker.pkg.dev'
           username: 'oauth2accesstoken'

--- a/.github/workflows/gemini-issue-automated-triage.yml
+++ b/.github/workflows/gemini-issue-automated-triage.yml
@@ -223,7 +223,8 @@ jobs:
               },
               "coreTools": [
                 "run_shell_command(gh issue comment)",
-                "run_shell_command(gh issue view)"
+                "run_shell_command(gh issue view)",
+                "run_shell_command(gh issue edit)"
               ],
               "telemetry": {
                 "enabled": true,
@@ -235,8 +236,9 @@ jobs:
             ## Role
 
             You are an issue de-duplication assistant. Your goal is to find
-            duplicate issues and notify the user by commenting on the current
-            issue, while avoiding duplicate comments.
+            duplicate issues, label the current issue as a duplicate, and notify
+            the user by commenting on the current issue, while avoiding
+            duplicate comments.
 
             ## Steps
 
@@ -277,11 +279,15 @@ jobs:
                     - Create a new comment with the list of duplicates.
                     - Use `gh issue comment "${ISSUE_NUMBER}" --body "..."`.
 
+            6.  **Add Duplicate Label:**
+                - If you created or updated a comment in the previous step, add the `duplicate` label to the current issue.
+                - Use `gh issue edit "${ISSUE_NUMBER}" --add-label "duplicate"`.
+
             ## Guidelines
 
             - Only use the `duplicates` and `run_shell_command` tools.
-            - The `run_shell_command` tool can be used with `gh issue view` and `gh issue comment`.
+            - The `run_shell_command` tool can be used with `gh issue view`, `gh issue comment`, and `gh issue edit`.
             - Do not download or read media files like images, videos, or links. The `--json` flag for `gh issue view` will prevent this.
-            - Do not modify the issue content, labels, or status.
-            - Only comment on the current issue.
+            - Do not modify the issue content or status.
+            - Only comment on and label the current issue.
             - Reference all shell variables as "${VAR}" (with quotes and braces)

--- a/.github/workflows/gemini-issue-automated-triage.yml
+++ b/.github/workflows/gemini-issue-automated-triage.yml
@@ -158,6 +158,12 @@ jobs:
 
       - name: 'Start AlloyDB Auth Proxy'
         run: ./alloydb-auth-proxy "${{ vars.ALLOYDB_INSTANCE_CONNECTION_NAME }}" --public-ip -i --impersonate-service-account ${{ vars.SERVICE_ACCOUNT_EMAIL }} &
+      - name: 'Test AlloyDB Auth Proxy'
+        env:
+          DB_USER: 'postgres'
+          DB_PASS: '${{ secrets.ALLOYDB_DB_PASS }}'
+        run: |
+          PGPASSWORD=$DB_PASS psql "host=127.0.0.1 port=5432 user=$DB_USER dbname=postgres  sslmode=disable" --command="SELECT 1;"
 
       - name: 'Run Gemini Issue Deduplication'
         uses: './'
@@ -165,6 +171,8 @@ jobs:
           GITHUB_TOKEN: '${{ steps.generate_token.outputs.token || secrets.GITHUB_TOKEN }}'
           ISSUE_NUMBER: '${{ github.event.issue.number }}'
           REPOSITORY: '${{ github.repository }}'
+          REPO_OWNER: '${{ github.repository_owner }}'
+          REPO_NAME: '${{ github.event.repository.name }}'
           GEMINI_CLI_VERSION: '${{ vars.GEMINI_CLI_VERSION }}'
           OTLP_GOOGLE_CLOUD_PROJECT: '${{ vars.OTLP_GOOGLE_CLOUD_PROJECT }}'
           GCP_WIF_PROVIDER: '${{ vars.GCP_WIF_PROVIDER }}'
@@ -173,6 +181,7 @@ jobs:
           GOOGLE_CLOUD_LOCATION: '${{ vars.GOOGLE_CLOUD_LOCATION }}'
           GOOGLE_GENAI_USE_VERTEXAI: '${{ vars.GOOGLE_GENAI_USE_VERTEXAI }}'
           SERVICE_ACCOUNT_EMAIL: '${{ vars.SERVICE_ACCOUNT_EMAIL }}'
+          DB_USER: 'postgres'
           DB_PASS: '${{ secrets.ALLOYDB_DB_PASS }}'
           INSTANCE_HOST: '127.0.0.1'
           INSTANCE_PORT: '5432'
@@ -192,6 +201,8 @@ jobs:
                     "-e",
                     "GEMINI_API_KEY",
                     "-e",
+                    "DB_USER",
+                    "-e",
                     "DB_PASS",
                     "-e",
                     "INSTANCE_HOST",
@@ -202,6 +213,7 @@ jobs:
                   "env": {
                     "GITHUB_TOKEN": "${GITHUB_TOKEN}",
                     "GEMINI_API_KEY": "${GEMINI_API_KEY}",
+                    "DB_USER": "postgres",
                     "DB_PASS": "${DB_PASS}",
                     "INSTANCE_HOST": "${INSTANCE_HOST}",
                     "INSTANCE_PORT": "${INSTANCE_PORT}"
@@ -229,8 +241,7 @@ jobs:
             ## Steps
 
             1.  **Find Potential Duplicates:**
-                - The full repository name is available in the `${REPOSITORY}` environment variable (e.g., "owner/repo"). You will need to parse this to get the `repo_owner` and `repo_name`.
-                - The issue number is available in the `${ISSUE_NUMBER}` environment variable.
+                - The repo_owner/repo_name is ${{ github.repository }} and the issue number is ${{ github.event.issue.number }}.
                 - Use the `duplicates` tool with the `repo_owner`, `repo_name`, and `issue_number` to find potential duplicates for the current issue. Do not use the `threshold` parameter.
                 - If no duplicates are found, you are done.
 

--- a/.github/workflows/gemini-issue-automated-triage.yml
+++ b/.github/workflows/gemini-issue-automated-triage.yml
@@ -222,6 +222,7 @@ jobs:
                 }
               },
               "coreTools": [
+                "run_shell_command(echo)",
                 "run_shell_command(gh issue comment)",
                 "run_shell_command(gh issue view)",
                 "run_shell_command(gh issue edit)"
@@ -246,6 +247,7 @@ jobs:
                 - The repository is ${{ github.repository }} and the issue number is ${{ github.event.issue.number }}.
                 - Use the `duplicates` tool with the `repo` and `issue_number` to find potential duplicates for the current issue. Do not use the `threshold` parameter.
                 - If no duplicates are found, you are done.
+                - Print the JSON output from the `duplicates` tool to the logs.
 
             2.  **Refine Duplicates List (if necessary):**
                 - If the `duplicates` tool returns between 1 and 14 results, you must refine the list.
@@ -254,6 +256,7 @@ jobs:
                 - Carefully analyze the content (title, body, comments) of the original issue and all potential duplicates.
                 - Based on your analysis, create a final list containing only the issues you are highly confident are actual duplicates.
                 - If your final list is empty, you are done.
+                - Print to the logs if you omitted any potential duplicates based on your analysis.
                 - If the `duplicates` tool returned 15+ results, use the top 15 matches (based on descending similarity score value) to perform this step.
 
             3.  **Format Final Duplicates List:**

--- a/.github/workflows/gemini-issue-automated-triage.yml
+++ b/.github/workflows/gemini-issue-automated-triage.yml
@@ -123,7 +123,7 @@ jobs:
        (github.event.comment.author_association == 'OWNER' ||
         github.event.comment.author_association == 'MEMBER' ||
         github.event.comment.author_association == 'COLLABORATOR'))
-    timeout-minutes: 5
+    timeout-minutes: 10
     runs-on: 'ubuntu-latest'
 
     steps:
@@ -158,6 +158,7 @@ jobs:
 
       - name: 'Start AlloyDB Auth Proxy'
         run: ./alloydb-auth-proxy "${{ vars.ALLOYDB_INSTANCE_CONNECTION_NAME }}" --public-ip -i --impersonate-service-account ${{ vars.SERVICE_ACCOUNT_EMAIL }} &
+
       - name: 'Test AlloyDB Auth Proxy'
         env:
           DB_USER: 'postgres'

--- a/.github/workflows/gemini-issue-automated-triage.yml
+++ b/.github/workflows/gemini-issue-automated-triage.yml
@@ -48,8 +48,7 @@ jobs:
 
       - name: 'Generate GitHub App Token'
         id: 'generate_token'
-        if: |-
-          ${{ vars.APP_ID }}
+        if: vars.APP_ID != ''
         uses: 'actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e' # ratchet:actions/create-github-app-token@v2
         with:
           app-id: '${{ vars.APP_ID }}'
@@ -116,7 +115,7 @@ jobs:
 
   deduplicate-issues:
     if: >
-      vars.ALLOYDB_INSTANCE_CONNECTION_NAME &&
+      vars.ALLOYDB_INSTANCE_CONNECTION_NAME != '' &&
       (github.event_name == 'issues' ||
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'issue_comment' &&
@@ -133,8 +132,7 @@ jobs:
 
       - name: 'Generate GitHub App Token'
         id: 'generate_token'
-        if: |-
-          ${{ vars.APP_ID }}
+        if: vars.APP_ID != ''
         uses: 'actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e' # ratchet:actions/create-github-app-token@v2
         with:
           app-id: '${{ vars.APP_ID }}'

--- a/.github/workflows/gemini-issue-automated-triage.yml
+++ b/.github/workflows/gemini-issue-automated-triage.yml
@@ -113,3 +113,164 @@ jobs:
             - Triage only the current issue
             - Assign all applicable labels based on the issue content
             - Reference all shell variables as "${VAR}" (with quotes and braces)
+
+  deduplicate-issues:
+    if: >
+      github.event_name == 'issues' ||
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'issue_comment' &&
+       contains(github.event.comment.body, '@gemini-cli /deduplicate') &&
+       (github.event.comment.author_association == 'OWNER' ||
+        github.event.comment.author_association == 'MEMBER' ||
+        github.event.comment.author_association == 'COLLABORATOR'))
+    timeout-minutes: 5
+    runs-on: 'ubuntu-latest'
+
+    steps:
+      - name: 'Checkout repository'
+        uses: 'actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683' # ratchet:actions/checkout@v4
+
+      - name: 'Generate GitHub App Token'
+        id: 'generate_token'
+        if: |-
+          ${{ vars.APP_ID }}
+        uses: 'actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e' # ratchet:actions/create-github-app-token@v2
+        with:
+          app-id: '${{ vars.APP_ID }}'
+          private-key: '${{ secrets.APP_PRIVATE_KEY }}'
+
+      - id: 'auth'
+        uses: 'google-github-actions/auth@v2'
+        with:
+          workload_identity_provider: '${{ vars.GCP_WIF_PROVIDER }}'
+          service_account: '${{ vars.SERVICE_ACCOUNT_EMAIL }}'
+
+      - name: 'Set up Cloud SDK'
+        uses: 'google-github-actions/setup-gcloud@v2'
+
+      - name: 'Configure Docker for Artifact Registry'
+        run: gcloud auth configure-docker northamerica-northeast1-docker.pkg.dev
+
+      - name: 'Download AlloyDB Auth Proxy'
+        run: |
+          curl -o alloydb-auth-proxy https://storage.googleapis.com/alloydb-auth-proxy/v1.13.4/alloydb-auth-proxy.linux.amd64
+          chmod +x alloydb-auth-proxy
+
+      - name: 'Start AlloyDB Auth Proxy'
+        run: ./alloydb-auth-proxy "${{ vars.ALLOYDB_INSTANCE_CONNECTION_NAME }}" --public-ip -i --impersonate-service-account ${{ vars.SERVICE_ACCOUNT_EMAIL }} &
+
+      - name: 'Run Gemini Issue Deduplication'
+        uses: './'
+        env:
+          GITHUB_TOKEN: '${{ steps.generate_token.outputs.token || secrets.GITHUB_TOKEN }}'
+          ISSUE_NUMBER: '${{ github.event.issue.number }}'
+          REPOSITORY: '${{ github.repository }}'
+          GEMINI_CLI_VERSION: '${{ vars.GEMINI_CLI_VERSION }}'
+          OTLP_GOOGLE_CLOUD_PROJECT: '${{ vars.OTLP_GOOGLE_CLOUD_PROJECT }}'
+          GCP_WIF_PROVIDER: '${{ vars.GCP_WIF_PROVIDER }}'
+          GEMINI_API_KEY: '${{ secrets.GEMINI_API_KEY }}'
+          GOOGLE_CLOUD_PROJECT: '${{ vars.GOOGLE_CLOUD_PROJECT }}'
+          GOOGLE_CLOUD_LOCATION: '${{ vars.GOOGLE_CLOUD_LOCATION }}'
+          GOOGLE_GENAI_USE_VERTEXAI: '${{ vars.GOOGLE_GENAI_USE_VERTEXAI }}'
+          SERVICE_ACCOUNT_EMAIL: '${{ vars.SERVICE_ACCOUNT_EMAIL }}'
+          DB_PASS: '${{ secrets.ALLOYDB_DB_PASS }}'
+          INSTANCE_HOST: '127.0.0.1'
+          INSTANCE_PORT: '5432'
+        with:
+          settings: |-
+            {
+              "mcpServers": {
+                "issue_deduplication": {
+                  "command": "docker",
+                  "args": [
+                    "run",
+                    "-i",
+                    "--rm",
+                    "--network=host",
+                    "-e",
+                    "GITHUB_TOKEN",
+                    "-e",
+                    "GEMINI_API_KEY",
+                    "-e",
+                    "DB_PASS",
+                    "-e",
+                    "INSTANCE_HOST",
+                    "-e",
+                    "INSTANCE_PORT",
+                    "northamerica-northeast1-docker.pkg.dev/quacktastic-waffle/run-gemini-cli/issues-dedup-mcp-server:latest"
+                  ],
+                  "env": {
+                    "GITHUB_TOKEN": "${GITHUB_TOKEN}",
+                    "GEMINI_API_KEY": "${GEMINI_API_KEY}",
+                    "DB_PASS": "${DB_PASS}",
+                    "INSTANCE_HOST": "${INSTANCE_HOST}",
+                    "INSTANCE_PORT": "${INSTANCE_PORT}"
+                  },
+                  "enabled": true
+                }
+              },
+              "coreTools": [
+                "run_shell_command(gh issue comment)",
+                "run_shell_command(gh issue view)"
+              ],
+              "telemetry": {
+                "enabled": true,
+                "target": "gcp"
+              },
+              "sandbox": false
+            }
+          prompt: |-
+            ## Role
+
+            You are an issue de-duplication assistant. Your goal is to find
+            duplicate issues and notify the user by commenting on the current
+            issue, while avoiding duplicate comments.
+
+            ## Steps
+
+            1.  **Find Potential Duplicates:**
+                - The full repository name is available in the `${REPOSITORY}` environment variable (e.g., "owner/repo"). You will need to parse this to get the `repo_owner` and `repo_name`.
+                - The issue number is available in the `${ISSUE_NUMBER}` environment variable.
+                - Use the `duplicates` tool with the `repo_owner`, `repo_name`, and `issue_number` to find potential duplicates for the current issue. Do not use the `threshold` parameter.
+                - If no duplicates are found, you are done.
+
+            2.  **Refine Duplicates List (if necessary):**
+                - If the `duplicates` tool returns between 1 and 14 results, you must refine the list.
+                - For each potential duplicate issue, run `gh issue view <issue-number> --json title,body,comments` to fetch its content.
+                - Also fetch the content of the original issue: `gh issue view "${ISSUE_NUMBER}" --json title,body,comments`.
+                - Carefully analyze the content (title, body, comments) of the original issue and all potential duplicates.
+                - Based on your analysis, create a final list containing only the issues you are highly confident are actual duplicates.
+                - If your final list is empty, you are done.
+                - If the `duplicates` tool returned 15+ results, use the top 15 matches (based on descending similarity score value) to perform this step.
+
+            3.  **Format Final Duplicates List:**
+                Format the final list of duplicates into a markdown string.
+                The format should be:
+                "Found possible duplicate issues:\n\n- #${issue_number}: ${issue_title}"
+                Add an HTML comment to the end for identification: `<!-- gemini-cli-deduplication -->`
+
+            4.  **Check for Existing Comment:**
+                - Run `gh issue view "${ISSUE_NUMBER}" --json comments` to get all
+                  comments on the issue.
+                - Look for a comment made by a bot (the author's login often ends in `[bot]`) that contains `<!-- gemini-cli-deduplication -->`.
+                - If you find such a comment, store its `id` and `body`.
+
+            5.  **Decide Action:**
+                - **If an existing comment is found:**
+                    - Compare the new list of duplicate issues with the list from the existing comment's body.
+                    - If they are the same, do nothing.
+                    - If they are different, edit the existing comment. Use
+                      `gh issue comment "${ISSUE_NUMBER}" --edit-comment <comment-id> --body "..."`.
+                      The new body should be the new list of duplicates, but with the header "Found possible duplicate issues (updated):".
+                - **If no existing comment is found:**
+                    - Create a new comment with the list of duplicates.
+                    - Use `gh issue comment "${ISSUE_NUMBER}" --body "..."`.
+
+            ## Guidelines
+
+            - Only use the `duplicates` and `run_shell_command` tools.
+            - The `run_shell_command` tool can be used with `gh issue view` and `gh issue comment`.
+            - Do not download or read media files like images, videos, or links. The `--json` flag for `gh issue view` will prevent this.
+            - Do not modify the issue content, labels, or status.
+            - Only comment on the current issue.
+            - Reference all shell variables as "${VAR}" (with quotes and braces)

--- a/.github/workflows/gemini-issue-scheduled-triage.yml
+++ b/.github/workflows/gemini-issue-scheduled-triage.yml
@@ -123,7 +123,8 @@ jobs:
             - Reference all shell variables as "${VAR}" (with quotes and braces)
 
   refresh-embeddings:
-    if: vars.ALLOYDB_INSTANCE_CONNECTION_NAME
+    if: |-
+      ${{ vars.ALLOYDB_INSTANCE_CONNECTION_NAME }}
     timeout-minutes: 20
     runs-on: 'ubuntu-latest'
     steps:
@@ -140,16 +141,17 @@ jobs:
           private-key: '${{ secrets.APP_PRIVATE_KEY }}'
 
       - id: 'auth'
-        uses: 'google-github-actions/auth@v2'
+        uses: 'google-github-actions/auth@140bb5113ffb6b65a7e9b937a81fa96cf5064462' # ratchet:google-github-actions/auth@v2
         with:
           workload_identity_provider: '${{ vars.GCP_WIF_PROVIDER }}'
           service_account: '${{ vars.SERVICE_ACCOUNT_EMAIL }}'
 
       - name: 'Set up Cloud SDK'
-        uses: 'google-github-actions/setup-gcloud@v2'
+        uses: 'google-github-actions/setup-gcloud@6189d56e4096ee891640bb02ac264be376592d6a' # ratchet:google-github-actions/setup-gcloud@v2
 
       - name: 'Configure Docker for Artifact Registry'
-        run: gcloud auth configure-docker northamerica-northeast1-docker.pkg.dev
+        run: |-
+          gcloud auth configure-docker northamerica-northeast1-docker.pkg.dev
 
       - name: 'Download AlloyDB Auth Proxy'
         run: |
@@ -157,7 +159,8 @@ jobs:
           chmod +x alloydb-auth-proxy
 
       - name: 'Start AlloyDB Auth Proxy'
-        run: ./alloydb-auth-proxy "${{ vars.ALLOYDB_INSTANCE_CONNECTION_NAME }}" --public-ip -i --impersonate-service-account ${{ vars.SERVICE_ACCOUNT_EMAIL }} &
+        run: |-
+          ./alloydb-auth-proxy "${{ vars.ALLOYDB_INSTANCE_CONNECTION_NAME }}" --public-ip -i --impersonate-service-account ${{ vars.SERVICE_ACCOUNT_EMAIL }} &
 
       - name: 'Test AlloyDB Auth Proxy'
         env:

--- a/.github/workflows/gemini-issue-scheduled-triage.yml
+++ b/.github/workflows/gemini-issue-scheduled-triage.yml
@@ -158,6 +158,13 @@ jobs:
       - name: 'Start AlloyDB Auth Proxy'
         run: ./alloydb-auth-proxy "${{ vars.ALLOYDB_INSTANCE_CONNECTION_NAME }}" --public-ip -i --impersonate-service-account ${{ vars.SERVICE_ACCOUNT_EMAIL }} &
 
+      - name: 'Test AlloyDB Auth Proxy'
+        env:
+          DB_USER: 'postgres'
+          DB_PASS: '${{ secrets.ALLOYDB_DB_PASS }}'
+        run: |
+          PGPASSWORD=$DB_PASS psql "host=127.0.0.1 port=5432 user=$DB_USER dbname=postgres  sslmode=disable" --command="SELECT 1;"
+
       - name: 'Run Gemini Issue Deduplication Refresh'
         uses: './'
         env:
@@ -173,6 +180,7 @@ jobs:
           GOOGLE_CLOUD_LOCATION: '${{ vars.GOOGLE_CLOUD_LOCATION }}'
           GOOGLE_GENAI_USE_VERTEXAI: '${{ vars.GOOGLE_GENAI_USE_VERTEXAI }}'
           SERVICE_ACCOUNT_EMAIL: '${{ vars.SERVICE_ACCOUNT_EMAIL }}'
+          DB_USER: 'postgres'
           DB_PASS: '${{ secrets.ALLOYDB_DB_PASS }}'
           INSTANCE_HOST: '127.0.0.1'
           INSTANCE_PORT: '5432'
@@ -180,7 +188,7 @@ jobs:
           settings: |-
             {
              "coreTools": [
-                "run_shell_command(echo)",
+                "run_shell_command(echo)"
               ],
               "mcpServers": {
                 "issue_deduplication": {
@@ -195,6 +203,8 @@ jobs:
                     "-e",
                     "GEMINI_API_KEY",
                     "-e",
+                    "DB_USER",
+                    "-e",
                     "DB_PASS",
                     "-e",
                     "INSTANCE_HOST",
@@ -205,6 +215,7 @@ jobs:
                   "env": {
                     "GITHUB_TOKEN": "${GITHUB_TOKEN}",
                     "GEMINI_API_KEY": "${GEMINI_API_KEY}",
+                    "DB_USER": "postgres",
                     "DB_PASS": "${DB_PASS}",
                     "INSTANCE_HOST": "${INSTANCE_HOST}",
                     "INSTANCE_PORT": "${INSTANCE_PORT}"

--- a/.github/workflows/gemini-issue-scheduled-triage.yml
+++ b/.github/workflows/gemini-issue-scheduled-triage.yml
@@ -163,6 +163,8 @@ jobs:
         env:
           GITHUB_TOKEN: '${{ steps.generate_token.outputs.token || secrets.GITHUB_TOKEN }}'
           REPOSITORY: '${{ github.repository }}'
+          REPO_OWNER: '${{ github.repository_owner }}'
+          REPO_NAME: '${{ github.event.repository.name }}'
           GEMINI_CLI_VERSION: '${{ vars.GEMINI_CLI_VERSION }}'
           OTLP_GOOGLE_CLOUD_PROJECT: '${{ vars.OTLP_GOOGLE_CLOUD_PROJECT }}'
           GCP_WIF_PROVIDER: '${{ vars.GCP_WIF_PROVIDER }}'
@@ -227,7 +229,7 @@ jobs:
 
             ## Steps
 
-            1.  **Extract Repository Information:** The full repository name is available in the `${REPOSITORY}` environment variable (e.g., "owner/repo"). You will need to parse this to get the `repo_owner` and `repo_name`.
+            1.  **Extract Repository Information:** The repo_owner/repo_name is ${{ github.repository }}.
             2.  **Refresh Embeddings:** Call the `refresh` tool with the correct `repo_owner` and `repo_name`. Do not use the `force` parameter.
             3.  **Log Output:** Print the JSON output from the `refresh` tool to the logs.
 

--- a/.github/workflows/gemini-issue-scheduled-triage.yml
+++ b/.github/workflows/gemini-issue-scheduled-triage.yml
@@ -30,8 +30,7 @@ jobs:
 
       - name: 'Generate GitHub App Token'
         id: 'generate_token'
-        if: |-
-          ${{ vars.APP_ID }}
+        if: vars.APP_ID != ''
         uses: 'actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e' # ratchet:actions/create-github-app-token@v2
         with:
           app-id: '${{ vars.APP_ID }}'
@@ -123,8 +122,7 @@ jobs:
             - Reference all shell variables as "${VAR}" (with quotes and braces)
 
   refresh-embeddings:
-    if: |-
-      ${{ vars.ALLOYDB_INSTANCE_CONNECTION_NAME }}
+    if: vars.ALLOYDB_INSTANCE_CONNECTION_NAME != ''
     timeout-minutes: 20
     runs-on: 'ubuntu-latest'
     steps:
@@ -133,8 +131,7 @@ jobs:
 
       - name: 'Generate GitHub App Token'
         id: 'generate_token'
-        if: |-
-          ${{ vars.APP_ID }}
+        if: vars.APP_ID != ''
         uses: 'actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e' # ratchet:actions/create-github-app-token@v2
         with:
           app-id: '${{ vars.APP_ID }}'

--- a/.github/workflows/gemini-issue-scheduled-triage.yml
+++ b/.github/workflows/gemini-issue-scheduled-triage.yml
@@ -123,6 +123,7 @@ jobs:
             - Reference all shell variables as "${VAR}" (with quotes and braces)
 
   refresh-embeddings:
+    if: vars.ALLOYDB_INSTANCE_CONNECTION_NAME
     timeout-minutes: 20
     runs-on: 'ubuntu-latest'
     steps:

--- a/.github/workflows/gemini-issue-scheduled-triage.yml
+++ b/.github/workflows/gemini-issue-scheduled-triage.yml
@@ -121,3 +121,118 @@ jobs:
             - Do not add comments
             - Triage each issue independently
             - Reference all shell variables as "${VAR}" (with quotes and braces)
+
+  refresh-embeddings:
+    timeout-minutes: 20
+    runs-on: 'ubuntu-latest'
+    steps:
+      - name: 'Checkout repository'
+        uses: 'actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683' # ratchet:actions/checkout@v4
+
+      - name: 'Generate GitHub App Token'
+        id: 'generate_token'
+        if: |-
+          ${{ vars.APP_ID }}
+        uses: 'actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e' # ratchet:actions/create-github-app-token@v2
+        with:
+          app-id: '${{ vars.APP_ID }}'
+          private-key: '${{ secrets.APP_PRIVATE_KEY }}'
+
+      - id: 'auth'
+        uses: 'google-github-actions/auth@v2'
+        with:
+          workload_identity_provider: '${{ vars.GCP_WIF_PROVIDER }}'
+          service_account: '${{ vars.SERVICE_ACCOUNT_EMAIL }}'
+
+      - name: 'Set up Cloud SDK'
+        uses: 'google-github-actions/setup-gcloud@v2'
+
+      - name: 'Configure Docker for Artifact Registry'
+        run: gcloud auth configure-docker northamerica-northeast1-docker.pkg.dev
+
+      - name: 'Download AlloyDB Auth Proxy'
+        run: |
+          curl -o alloydb-auth-proxy https://storage.googleapis.com/alloydb-auth-proxy/v1.13.4/alloydb-auth-proxy.linux.amd64
+          chmod +x alloydb-auth-proxy
+
+      - name: 'Start AlloyDB Auth Proxy'
+        run: ./alloydb-auth-proxy "${{ vars.ALLOYDB_INSTANCE_CONNECTION_NAME }}" --public-ip -i --impersonate-service-account ${{ vars.SERVICE_ACCOUNT_EMAIL }} &
+
+      - name: 'Run Gemini Issue Deduplication Refresh'
+        uses: './'
+        env:
+          GITHUB_TOKEN: '${{ steps.generate_token.outputs.token || secrets.GITHUB_TOKEN }}'
+          REPOSITORY: '${{ github.repository }}'
+          GEMINI_CLI_VERSION: '${{ vars.GEMINI_CLI_VERSION }}'
+          OTLP_GOOGLE_CLOUD_PROJECT: '${{ vars.OTLP_GOOGLE_CLOUD_PROJECT }}'
+          GCP_WIF_PROVIDER: '${{ vars.GCP_WIF_PROVIDER }}'
+          GEMINI_API_KEY: '${{ secrets.GEMINI_API_KEY }}'
+          GOOGLE_CLOUD_PROJECT: '${{ vars.GOOGLE_CLOUD_PROJECT }}'
+          GOOGLE_CLOUD_LOCATION: '${{ vars.GOOGLE_CLOUD_LOCATION }}'
+          GOOGLE_GENAI_USE_VERTEXAI: '${{ vars.GOOGLE_GENAI_USE_VERTEXAI }}'
+          SERVICE_ACCOUNT_EMAIL: '${{ vars.SERVICE_ACCOUNT_EMAIL }}'
+          DB_PASS: '${{ secrets.ALLOYDB_DB_PASS }}'
+          INSTANCE_HOST: '127.0.0.1'
+          INSTANCE_PORT: '5432'
+        with:
+          settings: |-
+            {
+             "coreTools": [
+                "run_shell_command(echo)",
+              ],
+              "mcpServers": {
+                "issue_deduplication": {
+                  "command": "docker",
+                  "args": [
+                    "run",
+                    "-i",
+                    "--rm",
+                    "--network=host",
+                    "-e",
+                    "GITHUB_TOKEN",
+                    "-e",
+                    "GEMINI_API_KEY",
+                    "-e",
+                    "DB_PASS",
+                    "-e",
+                    "INSTANCE_HOST",
+                    "-e",
+                    "INSTANCE_PORT",
+                    "northamerica-northeast1-docker.pkg.dev/quacktastic-waffle/run-gemini-cli/issues-dedup-mcp-server:latest"
+                  ],
+                  "env": {
+                    "GITHUB_TOKEN": "${GITHUB_TOKEN}",
+                    "GEMINI_API_KEY": "${GEMINI_API_KEY}",
+                    "DB_PASS": "${DB_PASS}",
+                    "INSTANCE_HOST": "${INSTANCE_HOST}",
+                    "INSTANCE_PORT": "${INSTANCE_PORT}"
+                  },
+                  "enabled": true
+                }
+              },
+              "telemetry": {
+                "enabled": true,
+                "target": "gcp"
+              },
+              "sandbox": false
+            }
+          prompt: |-
+            ## Role
+
+            You are a database maintenance assistant for a GitHub issue deduplication system.
+
+            ## Goal
+
+            Your sole responsibility is to refresh the embeddings for all open issues in the repository to ensure the deduplication database is up-to-date.
+
+            ## Steps
+
+            1.  **Extract Repository Information:** The full repository name is available in the `${REPOSITORY}` environment variable (e.g., "owner/repo"). You will need to parse this to get the `repo_owner` and `repo_name`.
+            2.  **Refresh Embeddings:** Call the `refresh` tool with the correct `repo_owner` and `repo_name`. Do not use the `force` parameter.
+            3.  **Log Output:** Print the JSON output from the `refresh` tool to the logs.
+
+            ## Guidelines
+
+            - Only use the `refresh` tool.
+            - Do not attempt to find duplicates or modify any issues.
+            - Your only task is to call the `refresh` tool and log its output.

--- a/.github/workflows/gemini-issue-scheduled-triage.yml
+++ b/.github/workflows/gemini-issue-scheduled-triage.yml
@@ -30,7 +30,8 @@ jobs:
 
       - name: 'Generate GitHub App Token'
         id: 'generate_token'
-        if: vars.APP_ID != ''
+        if: |-
+          ${{ vars.APP_ID != '' }}
         uses: 'actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e' # ratchet:actions/create-github-app-token@v2
         with:
           app-id: '${{ vars.APP_ID }}'
@@ -122,7 +123,8 @@ jobs:
             - Reference all shell variables as "${VAR}" (with quotes and braces)
 
   refresh-embeddings:
-    if: vars.ALLOYDB_INSTANCE_CONNECTION_NAME != ''
+    if: |-
+      ${{ vars.ALLOYDB_INSTANCE_CONNECTION_NAME != '' }}
     timeout-minutes: 20
     runs-on: 'ubuntu-latest'
     steps:
@@ -131,7 +133,8 @@ jobs:
 
       - name: 'Generate GitHub App Token'
         id: 'generate_token'
-        if: vars.APP_ID != ''
+        if: |-
+          ${{ vars.APP_ID != '' }}
         uses: 'actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e' # ratchet:actions/create-github-app-token@v2
         with:
           app-id: '${{ vars.APP_ID }}'
@@ -146,7 +149,7 @@ jobs:
           service_account: '${{ vars.SERVICE_ACCOUNT_EMAIL }}'
 
       - name: 'Login to GAR'
-        uses: 'docker/login-action@v3'
+        uses: 'docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772' # ratchet:docker/login-action@v3
         with:
           registry: 'northamerica-northeast1-docker.pkg.dev'
           username: 'oauth2accesstoken'

--- a/.github/workflows/gemini-issue-scheduled-triage.yml
+++ b/.github/workflows/gemini-issue-scheduled-triage.yml
@@ -137,18 +137,20 @@ jobs:
           app-id: '${{ vars.APP_ID }}'
           private-key: '${{ secrets.APP_PRIVATE_KEY }}'
 
-      - id: 'auth'
+      - name: 'Authenticate to Google Cloud'
+        id: 'auth'
         uses: 'google-github-actions/auth@140bb5113ffb6b65a7e9b937a81fa96cf5064462' # ratchet:google-github-actions/auth@v2
         with:
+          token_format: 'access_token'
           workload_identity_provider: '${{ vars.GCP_WIF_PROVIDER }}'
           service_account: '${{ vars.SERVICE_ACCOUNT_EMAIL }}'
 
-      - name: 'Set up Cloud SDK'
-        uses: 'google-github-actions/setup-gcloud@6189d56e4096ee891640bb02ac264be376592d6a' # ratchet:google-github-actions/setup-gcloud@v2
-
-      - name: 'Configure Docker for Artifact Registry'
-        run: |-
-          gcloud auth configure-docker northamerica-northeast1-docker.pkg.dev
+      - name: 'Login to GAR'
+        uses: 'docker/login-action@v3'
+        with:
+          registry: 'northamerica-northeast1-docker.pkg.dev'
+          username: 'oauth2accesstoken'
+          password: '${{ steps.auth.outputs.access_token }}'
 
       - name: 'Download AlloyDB Auth Proxy'
         run: |

--- a/.github/workflows/gemini-issue-scheduled-triage.yml
+++ b/.github/workflows/gemini-issue-scheduled-triage.yml
@@ -171,8 +171,6 @@ jobs:
         env:
           GITHUB_TOKEN: '${{ steps.generate_token.outputs.token || secrets.GITHUB_TOKEN }}'
           REPOSITORY: '${{ github.repository }}'
-          REPO_OWNER: '${{ github.repository_owner }}'
-          REPO_NAME: '${{ github.event.repository.name }}'
           GEMINI_CLI_VERSION: '${{ vars.GEMINI_CLI_VERSION }}'
           OTLP_GOOGLE_CLOUD_PROJECT: '${{ vars.OTLP_GOOGLE_CLOUD_PROJECT }}'
           GCP_WIF_PROVIDER: '${{ vars.GCP_WIF_PROVIDER }}'
@@ -241,8 +239,8 @@ jobs:
 
             ## Steps
 
-            1.  **Extract Repository Information:** The repo_owner/repo_name is ${{ github.repository }}.
-            2.  **Refresh Embeddings:** Call the `refresh` tool with the correct `repo_owner` and `repo_name`. Do not use the `force` parameter.
+            1.  **Extract Repository Information:** The repository is ${{ github.repository }}.
+            2.  **Refresh Embeddings:** Call the `refresh` tool with the correct `repo`. Do not use the `force` parameter.
             3.  **Log Output:** Print the JSON output from the `refresh` tool to the logs.
 
             ## Guidelines

--- a/scripts/issue-deduplication/Dockerfile
+++ b/scripts/issue-deduplication/Dockerfile
@@ -1,0 +1,41 @@
+# Use an official Python runtime as a parent image
+FROM python:3.11-slim
+
+# Install GitHub CLI
+RUN apt-get update && apt-get install -y curl gnupg && \
+    curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg && \
+    chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg && \
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null && \
+    apt-get update && \
+    apt-get install -y gh && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Set the working directory in the container
+WORKDIR /app
+
+# Copy the dependencies file to the working directory
+COPY requirements.txt .
+
+# Install any needed packages specified in requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy the content of the local src directory to the working directory
+COPY . .
+
+# Make port 8080 available to the world outside this container
+EXPOSE 8080
+
+# Define environment variables.
+ENV PORT=8080
+ENV INSTANCE_PORT=5432
+ENV DATABASE_NAME=postgres
+
+# Required environment variables to be set at runtime:
+# - GITHUB_TOKEN (gh will pick this up)
+# - GEMINI_API_KEY
+# - INSTANCE_HOST
+# - DB_USER
+# - DB_PASS
+
+# Run mcp_server.py when the container launches
+CMD ["python", "mcp_server.py"]

--- a/scripts/issue-deduplication/Dockerfile
+++ b/scripts/issue-deduplication/Dockerfile
@@ -1,13 +1,16 @@
 # Use an official Python runtime as a parent image
 FROM python:3.11-slim
 
+# Set the shell to fail on pipe errors
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
 # Install GitHub CLI
-RUN apt-get update && apt-get install -y curl gnupg && \
+RUN apt-get update && apt-get install -y --no-install-recommends curl gnupg && \
     curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg && \
     chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg && \
     echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null && \
     apt-get update && \
-    apt-get install -y gh && \
+    apt-get install -y --no-install-recommends gh=2.76.1 && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Set the working directory in the container

--- a/scripts/issue-deduplication/README.md
+++ b/scripts/issue-deduplication/README.md
@@ -150,8 +150,7 @@ This tool updates the embeddings for all open issues in a repository. It fetches
 
 **Arguments:**
 
-- `repo_owner` (str): The owner of the repository (e.g., `google-gemini`).
-- `repo_name` (str): The name of the repository (e.g., `gemini-cli`).
+- `repo` (str): The repository in the format 'owner/name' (e.g., `google-gemini/gemini-cli`).
 - `force` (bool, optional): If `True`, forces a refresh of all issues, ignoring the last refresh time. Defaults to `False`.
 
 **Returns:**
@@ -164,8 +163,7 @@ This tool finds duplicate issues for a given issue.
 
 **Arguments:**
 
-- `repo_owner` (str): The owner of the repository (e.g., `google-gemini`).
-- `repo_name` (str): The name of the repository (e.g., `gemini-cli`).
+- `repo` (str): The repository in the format 'owner/name' (e.g., `google-gemini/gemini-cli`).
 - `issue_number` (int): The number of the issue to find duplicates for.
 - `threshold` (float, optional): The similarity threshold for finding duplicates. Defaults to `0.9`.
 

--- a/scripts/issue-deduplication/README.md
+++ b/scripts/issue-deduplication/README.md
@@ -60,7 +60,10 @@ jobs:
       # 4. Start the Auth Proxy in the background
       # The proxy will listen on localhost (127.0.0.1) on port 5432.
       - name: 'Start AlloyDB Auth Proxy'
-        run: ./alloydb-auth-proxy projects/YOUR_PROJECT_ID/locations/YOUR_REGION/clusters/YOUR_CLUSTER_ID/instances/YOUR_INSTANCE_ID --public-ip -i &
+        run: ./alloydb-auth-proxy "YOUR_ALLOYDB_INSTANCE_CONNECTION_NAME" --public-ip -i --impersonate-service-account YOUR_SERVICE_ACCOUNT &
+
+      # The `YOUR_ALLOYDB_INSTANCE_CONNECTION_NAME` is the full connection string for your AlloyDB instance, 
+      # for example: projects/YOUR_PROJECT_ID/locations/YOUR_REGION/clusters/YOUR_CLUSTER_ID/instances/YOUR_INSTANCE_ID
 
 ```
 
@@ -101,7 +104,7 @@ The recommended way to run the server is by using the provided Dockerfile.
       mcp-server
     ```
 
-### 3.  Configure `gemini-cli`:**
+3.  **Configure `gemini-cli`:**
 
     To have `gemini-cli` use the running MCP server, you need to update your `settings.json` file. Add a new entry to the `mcpServers` object as shown below. This configuration allows `gemini-cli` to pass the required environment variables to the container securely.
 

--- a/scripts/issue-deduplication/README.md
+++ b/scripts/issue-deduplication/README.md
@@ -1,0 +1,171 @@
+# MCP Server for GitHub Issue Deduplication
+
+This server provides tools to find duplicate GitHub issues within a repository. It uses embeddings to represent the semantic meaning of an issue's title, body, and comments, and then compares these embeddings to find similarities.
+
+The server is built using `FastMCP` and provides two main tools: `refresh` and `duplicates`.
+
+## Setup
+
+The setup process involves provisioning an AlloyDB database on Google Cloud and then configuring the server to connect to it.
+
+### 1. Provision the AlloyDB Database
+
+The `setup_alloydb.sh` script automates the creation of a new AlloyDB cluster and instance on Google Cloud.
+
+**Usage:**
+
+```bash
+./setup_alloydb.sh --db-password YOUR_PASSWORD [OPTIONS]
+```
+
+**For Local Development:**
+
+To run the server locally, you should configure the database to allow connections from your public IP address.
+
+```bash
+./setup_alloydb.sh \
+  --db-password "YOUR_SUPER_SECRET_PASSWORD" \
+  --ip-address "YOUR.IP.ADDRESS.0/32"
+```
+
+**For GitHub Actions**:
+
+When running in a CI/CD environment like GitHub Actions, you should use a service account for authentication. The script will create the service account and grant it the necessary permissions. You can use the `principalSet` created when setting up [Workload Identify Federation](../setup_workload_identity.sh).
+
+
+```bash
+./setup_alloydb.sh \
+  --project-id "YOUR_PROJECT_ID" \
+  --region "YOUR_REGION" \
+  --db-password "YOUR_SUPER_SECRET_PASSWORD" \
+  --service-account "my-alloydb-sa" \
+  --principal-set "//iam.googleapis.com/projects/123/locations/global/workloadIdentityPools/my-pool/subject/my-subject"
+```
+
+The script will output the necessary connection details upon completion.
+
+You will also need to configure a step in your GitHub Actions workflow to run the AlloyDB Auth Proxy. This allows your action to securely connect to the database instance over localhost. The proxy will run as a background process.
+
+```yaml
+jobs:
+    ...
+    steps:
+        ...
+      # Download and install the AlloyDB Auth Proxy
+      - name: 'Download AlloyDB Auth Proxy'
+        run: |
+          curl -o alloydb-auth-proxy https://storage.googleapis.com/alloydb-auth-proxy/v1.13.4/alloydb-auth-proxy.linux.amd64
+          chmod +x alloydb-auth-proxy
+
+      # 4. Start the Auth Proxy in the background
+      # The proxy will listen on localhost (127.0.0.1) on port 5432.
+      - name: 'Start AlloyDB Auth Proxy'
+        run: ./alloydb-auth-proxy projects/YOUR_PROJECT_ID/locations/YOUR_REGION/clusters/YOUR_CLUSTER_ID/instances/YOUR_INSTANCE_ID --public-ip -i &
+
+```
+
+
+### 2. Set Environment Variables
+
+Before running the server, you need to set the following environment variables based on the output from the setup script and your Gemini API key.
+
+- `GEMINI_API_KEY`: Your API key for the Gemini API, used for generating embeddings.
+- `DB_USER`: The username for your AlloyDB database (e.g., `postgres`).
+- `DB_PASS`: The password for your AlloyDB database.
+- `INSTANCE_HOST`: The IP address or hostname of your AlloyDB instance (`localhost`, if running through the proxy).
+- `INSTANCE_PORT`: The port number of your AlloyDB instance (default: 5432).
+- `DATABASE_NAME`: The name of the database to use (default: postgres).
+- `GITHUB_TOKEN`: Your Github Personal Access Token with repository read scope. 
+
+## How to Run
+
+The recommended way to run the server is by using the provided Dockerfile.
+
+1.  **Build the Docker image:**
+
+    ```bash
+    docker build -t mcp-server .
+    ```
+
+2.  **Run the Docker container:**
+
+    Pass the environment variables to the `docker run` command.
+
+    ```bash
+    docker run -i --rm \
+      -e GITHUB_TOKEN="your-github-pat-token-with-repo-read-access"
+      -e GEMINI_API_KEY="your-gemini-api-key" \
+      -e DB_USER="postgres" \
+      -e DB_PASS="your-password" \
+      -e INSTANCE_HOST="your-instance-ip" \
+      mcp-server
+    ```
+
+### 3.  Configure `gemini-cli`:**
+
+    To have `gemini-cli` use the running MCP server, you need to update your `settings.json` file. Add a new entry to the `mcpServers` object as shown below. This configuration allows `gemini-cli` to pass the required environment variables to the container securely.
+
+    ```json
+    {
+      "mcpServers": {
+        "issue_deduplication": {
+          "command": "docker",
+          "args": [
+            "run",
+            "-i",
+            "--rm",
+            "-e",
+            "GITHUB_TOKEN",
+            "-e",
+            "GEMINI_API_KEY",
+            "-e",
+            "DB_USER",
+            "-e",
+            "DB_PASS",
+            "-e",
+            "INSTANCE_HOST",
+            "mcp-server"
+          ],
+          "env": {
+            "GITHUB_TOKEN": "${GITHUB_TOKEN}",
+            "GEMINI_API_KEY": "${GEMINI_API_KEY}",
+            "DB_USER": "${DB_USER}",
+            "DB_PASS": "${DB_PASS}",
+            "INSTANCE_HOST": "${INSTANCE_HOST}"
+          },
+          "enabled": true
+        }
+      }
+    }
+    ```
+
+## Tools
+
+### `refresh`
+
+This tool updates the embeddings for all open issues in a repository. It fetches the latest state of all open issues from GitHub, generates new embeddings for issues that have been updated since the last refresh, and stores them in the database.
+
+**Arguments:**
+
+- `repo_owner` (str): The owner of the repository (e.g., `google-gemini`).
+- `repo_name` (str): The name of the repository (e.g., `gemini-cli`).
+- `force` (bool, optional): If `True`, forces a refresh of all issues, ignoring the last refresh time. Defaults to `False`.
+
+**Returns:**
+
+A JSON string indicating the number of issues processed.
+
+### `duplicates`
+
+This tool finds duplicate issues for a given issue.
+
+**Arguments:**
+
+- `repo_owner` (str): The owner of the repository (e.g., `google-gemini`).
+- `repo_name` (str): The name of the repository (e.g., `gemini-cli`).
+- `issue_number` (int): The number of the issue to find duplicates for.
+- `threshold` (float, optional): The similarity threshold for finding duplicates. Defaults to `0.9`.
+
+**Returns:**
+
+A JSON string with the original issue number, repository, and a list of duplicate issues. Each duplicate issue contains the issue number, title, and similarity score.

--- a/scripts/issue-deduplication/mcp_server.py
+++ b/scripts/issue-deduplication/mcp_server.py
@@ -314,7 +314,7 @@ def generate_and_save_embeddings_sync(engine, issues, repo_name, embedding_dim=7
 # --- MCP Tool Definition ---
 
 @mcp.tool()
-def refresh(repo_owner: str, repo_name: str, force: bool = False) -> str:
+def refresh(repo: str, force: bool = False) -> str:
     """
     Updates the embeddings for all open issues in a repository.
 
@@ -323,14 +323,12 @@ def refresh(repo_owner: str, repo_name: str, force: bool = False) -> str:
     last refresh, and storing them in the database.
 
     Args:
-        repo_owner: The owner of the repository, eg. `google-gemini`.
-        repo_name: The name of the repository, eg. `gemini-cli`.
+        repo: The repository in the format 'owner/name', e.g., `google-gemini/gemini-cli`.
         force: If True, forces a refresh of all issues, ignoring the last refresh time.
 
     Returns:
         A JSON string indicating the number of issues processed.
     """
-    repo = f"{repo_owner}/{repo_name}"
     logger.info(f"Starting embedding refresh for repository: {repo}")
 
     issues = get_issues_with_comments_sync(repo=repo)
@@ -351,14 +349,13 @@ def refresh(repo_owner: str, repo_name: str, force: bool = False) -> str:
 
 @mcp.tool()
 def duplicates(
-    repo_owner: str, repo_name: str, issue_number: int, threshold: float = 0.9
+    repo: str, issue_number: int, threshold: float = 0.9
 ) -> str:
     """
     Finds duplicate issues for a given issue.
     
     Args:
-        repo_owner: The owner of the repository, eg. `google-gemini`.
-        repo_name: The name of the repository, eg. `gemini-cli`.
+        repo: The repository in the format 'owner/name', e.g., `google-gemini/gemini-cli`.
         issue_number: The number of the issue to find duplicates for.
         threshold: The similarity threshold for finding duplicates. Do not specify threshold unless explicitly specified by the user.
 
@@ -367,7 +364,6 @@ def duplicates(
         Each duplicate issue contains the issue number, title, and similarity score.
     
     """
-    repo = f"{repo_owner}/{repo_name}"
     distance_threshold = 1 - threshold
 
     # Fetch issue data

--- a/scripts/issue-deduplication/mcp_server.py
+++ b/scripts/issue-deduplication/mcp_server.py
@@ -1,0 +1,426 @@
+import os
+import json
+import logging
+import subprocess
+import time
+from datetime import datetime, timezone
+from typing import AsyncGenerator
+import asyncio
+
+import sqlalchemy
+from google import genai
+import numpy as np
+from sqlalchemy.sql import text
+from fastmcp import FastMCP
+
+# Configure logging
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+EMBEDDING_BATCH_SIZE = 100
+GITHUB_API_BATCH_SIZE = 100
+INITIAL_DELAY = 1.0
+MAX_DELAY = 60.0
+BACKOFF_FACTOR = 2.0
+
+# --- Configuration ---
+EMBEDDING_MODEL = 'models/gemini-embedding-001'
+MAX_TOKEN_LIMIT = 2048
+API_KEY = os.getenv("GEMINI_API_KEY")
+if not API_KEY:
+    raise ValueError("GEMINI_API_KEY environment variable not set.")
+
+# --- AlloyDB Configuration ---
+INSTANCE_HOST = os.getenv("INSTANCE_HOST", "localhost")
+INSTANCE_PORT = os.getenv("INSTANCE_PORT", "5432")
+DATABASE_NAME = os.getenv("DATABASE_NAME", "postgres")
+DB_USER = os.getenv("DB_USER")
+DB_PASS = os.getenv("DB_PASS")
+
+if not all([DB_USER, DB_PASS]):
+    raise ValueError("DB_USER and DB_PASS environment variables must be set.")
+
+# Initialize FastMCP server
+mcp = FastMCP("MCP Server for gemini-cli triage", timeout=660.0)
+
+def get_db_connection() -> sqlalchemy.engine.base.Engine:
+    """Initializes a connection pool for AlloyDB."""
+    db_url = sqlalchemy.engine.url.URL.create(
+        drivername="postgresql+pg8000",
+        username=DB_USER,
+        password=DB_PASS,
+        host=INSTANCE_HOST,
+        port=int(INSTANCE_PORT),
+        database=DATABASE_NAME,
+    )
+    # Add connection pool arguments for better performance
+    engine = sqlalchemy.create_engine(
+        db_url, pool_size=5, max_overflow=2, pool_timeout=30, pool_recycle=1800
+    )
+    return engine
+
+engine = get_db_connection()
+
+# --- Blocking I/O Functions ---
+
+def init_database(engine):
+    """
+    Initializes the database table and vector extension if they don't exist.
+    """
+    print("Initializing database...")
+    with engine.connect() as conn:
+        conn.execute(text("CREATE EXTENSION IF NOT EXISTS vector;"))
+        conn.execute(text("""
+            CREATE TABLE IF NOT EXISTS issues (
+                number INTEGER,
+                repo_name TEXT,
+                title TEXT,
+                body TEXT,
+                comments TEXT,
+                github_updated_at TIMESTAMP,
+                token_count INTEGER,
+                truncated_text TEXT,
+                embedding vector(768),
+                embedding_last_refreshed_at TIMESTAMP,
+                PRIMARY KEY (number, repo_name)
+            );
+        """))
+        
+        conn.execute(text("""
+            CREATE INDEX IF NOT EXISTS issues_embedding_idx
+            ON issues
+            USING ivfflat (embedding vector_cosine_ops)
+            WITH (lists = 100);
+        """))
+        conn.commit()
+    print("Database initialization complete.")
+
+
+def get_issues_with_comments_sync(repo, issue_numbers=None):
+    """
+    Synchronous: Fetches issues and their comments from GitHub.
+    If issue_numbers is None, fetches all open issues.
+    """
+    if issue_numbers is None:
+        logger.info(f"Fetching all open issue numbers from GitHub for repo {repo}...")
+        try:
+            list_command = ["gh", "issue", "list", "--state", "open", "--json", "number,updatedAt", "--limit", "5000", "--repo", repo]
+            result = subprocess.run(list_command, capture_output=True, text=True, check=True)
+            metadata = json.loads(result.stdout)
+            issue_numbers = [item['number'] for item in metadata]
+            logger.info(f"Found {len(issue_numbers)} open issues.")
+        except (subprocess.CalledProcessError, json.JSONDecodeError) as e:
+            logger.error(f"Error fetching issue numbers for repo {repo}: {e}")
+            return []
+    
+    if not issue_numbers:
+        return []
+
+    logger.info(f"Fetching details for {len(issue_numbers)} issues with GraphQL...")
+    owner, name = repo.split('/')
+    all_issues = []
+
+    for i in range(0, len(issue_numbers), GITHUB_API_BATCH_SIZE):
+        batch_numbers = issue_numbers[i:i + GITHUB_API_BATCH_SIZE]
+        logger.info(f"Fetching issue batch {i//GITHUB_API_BATCH_SIZE + 1}/{(len(issue_numbers) + GITHUB_API_BATCH_SIZE - 1)//GITHUB_API_BATCH_SIZE}")
+        query_parts = [f"issue_{n}: issue(number: {n}) {{ title body updatedAt comments(first: 30) {{ nodes {{ body }} }} }}" for n in batch_numbers]
+        full_query = f"query {{ repository(owner: \"{owner}\", name: \"{name}\") {{ {' '.join(query_parts)} }} }}"
+        
+        try:
+            result = subprocess.run(["gh", "api", "graphql", "-f", f"query={full_query}"], capture_output=True, text=True, check=True)
+            response_data = json.loads(result.stdout)
+            
+            if "errors" in response_data:
+                logger.error(f"GraphQL API error: {response_data['errors']}")
+                continue
+
+            repo_data = response_data.get("data", {}).get("repository", {})
+            for number in batch_numbers:
+                issue_data = repo_data.get(f"issue_{number}")
+                if issue_data:
+                    issue_data["comments"] = issue_data.get("comments", {}).get("nodes", [])
+                    issue_data["number"] = number
+                    all_issues.append(issue_data)
+        except (subprocess.CalledProcessError, json.JSONDecodeError) as e:
+            logger.error(f"Error during GraphQL request for batch starting with #{batch_numbers[0]}: {e}")
+
+    logger.info("Finished fetching all issue details.")
+    return all_issues
+
+
+def save_issue_and_embedding_sync(issue, embedding, repo_name, token_count, truncated_text):
+    """Synchronous: Saves an issue and its embedding to AlloyDB."""
+    embedding_str = str(embedding.tolist()) if embedding is not None else None
+    comments_json = json.dumps(issue.get('comments', []))
+
+    stmt = text("""
+        INSERT INTO issues (number, repo_name, title, body, comments, github_updated_at, token_count, truncated_text, embedding, embedding_last_refreshed_at)
+        VALUES (:number, :repo_name, :title, :body, :comments, :github_updated_at, :token_count, :truncated_text, :embedding, :refreshed_at)
+        ON CONFLICT (number, repo_name) DO UPDATE
+        SET title = EXCLUDED.title,
+            body = EXCLUDED.body,
+            comments = EXCLUDED.comments,
+            github_updated_at = EXCLUDED.github_updated_at,
+            token_count = EXCLUDED.token_count,
+            truncated_text = EXCLUDED.truncated_text,
+            embedding = EXCLUDED.embedding,
+            embedding_last_refreshed_at = EXCLUDED.embedding_last_refreshed_at;
+    """)
+    with engine.connect() as conn:
+        conn.execute(stmt, {
+            "number": issue['number'], "repo_name": repo_name, "title": issue['title'],
+            "body": issue.get('body', ''), "comments": comments_json,
+            "github_updated_at": issue.get('updatedAt'), "token_count": token_count,
+            "truncated_text": truncated_text, "embedding": embedding_str,
+            "refreshed_at": datetime.now(timezone.utc) if embedding is not None else None
+        })
+        conn.commit()
+
+def generate_and_save_embedding_sync(issue, repo_name, embedding_dim=768):
+    """Synchronous: Generates and saves a single embedding."""
+    client = genai.Client(api_key=API_KEY)
+    comments_text = " ".join([comment['body'] for comment in issue.get('comments', [])])
+    full_text = f"Title: {issue['title']}\nBody: {issue['body']}\nComments: {comments_text}"
+
+    if len(full_text) > MAX_TOKEN_LIMIT * 6:
+        full_text = full_text[:MAX_TOKEN_LIMIT * 6]
+    
+    token_count = len(full_text.split())
+    text_to_embed = full_text
+    if token_count > MAX_TOKEN_LIMIT:
+        text_to_embed = text_to_embed[:len(text_to_embed) // 2]
+
+    try:
+        result = client.models.embed_content(
+            model=EMBEDDING_MODEL, contents=[text_to_embed],
+            config={'task_type': 'SEMANTIC_SIMILARITY', 'output_dimensionality': embedding_dim}
+        )
+        embedding_np = np.array(result.embeddings[0].values)
+        if embedding_dim != 3072:
+            norm = np.linalg.norm(embedding_np)
+            if norm > 0: embedding_np /= norm
+        
+        save_issue_and_embedding_sync(issue, embedding_np, repo_name, token_count, text_to_embed)
+        return embedding_np
+    except Exception as e:
+        logger.error(f"Error generating embedding for issue #{issue['number']}: {e}", exc_info=True)
+        return None
+
+def generate_and_save_embeddings_sync(engine, issues, repo_name, embedding_dim=768, force=False):
+    """
+    Synchronous: Generates embeddings for new or updated issues and saves them to AlloyDB.
+    """
+    logger.info("Checking for new or updated issues to process...")
+    client = genai.Client(api_key=API_KEY)
+    
+    if force:
+        logger.info("Force option is True, processing all issues.")
+        issues_to_process = issues
+    else:
+        with engine.connect() as conn:
+            result = conn.execute(text("SELECT number, github_updated_at, embedding_last_refreshed_at FROM issues WHERE repo_name = :repo"), {"repo": repo_name}).fetchall()
+            db_issues = {row[0]: {"github_updated_at": row[1], "refreshed_at": row[2]} for row in result}
+
+        issues_to_process = []
+        for issue in issues:
+            db_issue = db_issues.get(issue['number'])
+            gh_updated_at = datetime.fromisoformat(issue['updatedAt'].replace('Z', '+00:00'))
+
+            if not db_issue or not db_issue.get('refreshed_at') or not db_issue.get('github_updated_at'):
+                issues_to_process.append(issue)
+                continue
+
+            db_updated_at = db_issue['github_updated_at'].replace(tzinfo=timezone.utc)
+
+            if gh_updated_at > db_updated_at:
+                issues_to_process.append(issue)
+    
+    if not issues_to_process:
+        logger.info("All issue embeddings are up-to-date. Nothing to process.")
+        return 0
+
+    logger.info(f"Found {len(issues_to_process)} new or updated issues. Processing text and generating embeddings...")
+    
+    token_errors = []
+    uncached_issues_for_embedding = []
+
+    for issue in issues_to_process:
+        comments_text = " ".join([comment['body'] for comment in issue.get('comments', [])])
+        full_text = f"Title: {issue['title']}\nBody: {issue['body']}\nComments: {comments_text}"
+
+        if len(full_text) > MAX_TOKEN_LIMIT * 6:
+            full_text = full_text[:MAX_TOKEN_LIMIT * 6]
+        
+        try:
+            token_result = client.models.count_tokens(model="gemini-1.5-flash-latest", contents=full_text)
+            token_count = token_result.total_tokens
+            
+            text_to_embed = full_text
+            if token_count > MAX_TOKEN_LIMIT:
+                text_to_embed = text_to_embed[:len(text_to_embed) // 2]
+            
+            uncached_issues_for_embedding.append({
+                "issue": issue, "text": text_to_embed,
+                "token_count": token_count, "truncated_text": text_to_embed
+            })
+        except Exception as e:
+            token_errors.append((issue['number'], str(e)))
+
+    if token_errors:
+        logger.warning(f"{len(token_errors)} issues had token counting errors and were skipped.")
+
+    processed_count = 0
+    for i in range(0, len(uncached_issues_for_embedding), EMBEDDING_BATCH_SIZE):
+        batch = uncached_issues_for_embedding[i:i + EMBEDDING_BATCH_SIZE]
+        texts_to_embed = [item['text'] for item in batch]
+        
+        retry_count = 0
+        current_delay = INITIAL_DELAY
+        while retry_count < 5:
+            try:
+                result = client.models.embed_content(
+                    model=EMBEDDING_MODEL, contents=texts_to_embed,
+                    config={'task_type': 'SEMANTIC_SIMILARITY', 'output_dimensionality': embedding_dim}
+                )
+                
+                for j, item in enumerate(batch):
+                    issue = item['issue']
+                    token_count = item['token_count']
+                    truncated_text = item['truncated_text']
+                    
+                    embedding_np = np.array(result.embeddings[j].values)
+                    if embedding_dim != 3072:
+                        norm = np.linalg.norm(embedding_np)
+                        if norm > 0: embedding_np /= norm
+                    
+                    save_issue_and_embedding_sync(issue, embedding_np, repo_name, token_count, truncated_text)
+                
+                processed_count += len(batch)
+                logger.info(f"Processed and saved batch of {len(batch)} embeddings.")
+                break
+            except Exception as e:
+                if "429" in str(e):
+                    retry_count += 1
+                    logger.warning(f"Rate limit hit. Waiting {current_delay:.1f}s...")
+                    time.sleep(current_delay)
+                    current_delay *= BACKOFF_FACTOR
+                else:
+                    logger.error(f"Error generating embeddings for batch: {e}")
+                    break
+    
+    logger.info(f"Successfully processed and saved {processed_count} embeddings to AlloyDB.")
+    return processed_count
+
+# --- MCP Tool Definition ---
+
+@mcp.tool()
+def refresh(repo_owner: str, repo_name: str, force: bool = False) -> str:
+    """
+    Updates the embeddings for all open issues in a repository.
+
+    This involves fetching the latest state of all open issues from GitHub,
+    generating new embeddings for issues that have been updated since the
+    last refresh, and storing them in the database.
+
+    Args:
+        repo_owner: The owner of the repository, eg. `google-gemini`.
+        repo_name: The name of the repository, eg. `gemini-cli`.
+        force: If True, forces a refresh of all issues, ignoring the last refresh time.
+
+    Returns:
+        A JSON string indicating the number of issues processed.
+    """
+    repo = f"{repo_owner}/{repo_name}"
+    logger.info(f"Starting embedding refresh for repository: {repo}")
+
+    issues = get_issues_with_comments_sync(repo=repo)
+    if not issues:
+        message = f"No open issues found for repository '{repo}' or failed to fetch them."
+        logger.warning(message)
+        return json.dumps({"status": "completed", "message": message, "issues_processed": 0})
+    
+    # Initialize database if it doesn't exist
+    init_database(engine)
+
+    processed_count = generate_and_save_embeddings_sync(engine, issues, repo, force=force)
+    
+    message = f"Embedding refresh completed for repository '{repo}'. Processed {processed_count} issues."
+    logger.info(message)
+    return json.dumps({"status": "completed", "message": message, "issues_processed": processed_count})
+
+
+@mcp.tool()
+def duplicates(
+    repo_owner: str, repo_name: str, issue_number: int, threshold: float = 0.9
+) -> str:
+    """
+    Finds duplicate issues for a given issue.
+    
+    Args:
+        repo_owner: The owner of the repository, eg. `google-gemini`.
+        repo_name: The name of the repository, eg. `gemini-cli`.
+        issue_number: The number of the issue to find duplicates for.
+        threshold: The similarity threshold for finding duplicates. Do not specify threshold unless explicitly specified by the user.
+
+    Returns:
+        A JSON string with the original issue number, repository, and a list of duplicate issues.
+        Each duplicate issue contains the issue number, title, and similarity score.
+    
+    """
+    repo = f"{repo_owner}/{repo_name}"
+    distance_threshold = 1 - threshold
+
+    # Fetch issue data
+    gh_issue_data = get_issues_with_comments_sync(repo, issue_numbers=[issue_number])
+    if not gh_issue_data:
+        return json.dumps({"error": f"Could not fetch issue #{issue_number} from GitHub repository '{repo}'."})
+    gh_issue = gh_issue_data[0]
+
+    gh_updated_at = datetime.fromisoformat(gh_issue['updatedAt'].replace('Z', '+00:00'))
+    
+    # Initialize database if it doesn't exist
+    init_database(engine)
+
+    # Check for cached embedding
+    embedding_str = None
+    with engine.connect() as conn:
+        db_issue_result = conn.execute(text("SELECT github_updated_at, embedding FROM issues WHERE number = :num AND repo_name = :repo"), {"num": issue_number, "repo": repo}).fetchone()
+        if db_issue_result and db_issue_result[1]:
+            db_updated_at = db_issue_result[0].replace(tzinfo=timezone.utc) if db_issue_result[0] else None
+            if db_updated_at and gh_updated_at <= db_updated_at:
+                embedding_str = db_issue_result[1]
+
+    # Generate new embedding if needed
+    if embedding_str is None:
+        embedding_np = generate_and_save_embedding_sync(gh_issue, repo)
+        if embedding_np is None:
+            return json.dumps({"error": f"Failed to generate embedding for issue #{issue_number}."})
+        embedding_str = str(embedding_np.tolist())
+
+    # Find similar issues
+    with engine.connect() as conn:
+        similar_issues_query = text("""
+            SELECT number, title, (embedding <=> :embedding) as distance
+            FROM issues WHERE repo_name = :repo AND number != :num AND (embedding <=> :embedding) < :distance
+            ORDER BY distance ASC
+        """)
+        similar_issues_result = conn.execute(similar_issues_query, {
+            "embedding": embedding_str, "repo": repo, "num": issue_number, "distance": distance_threshold
+        }).fetchall()
+
+    duplicates = [{"number": row[0], "title": row[1], "similarity": 1 - row[2]} for row in similar_issues_result]
+    
+    return json.dumps({
+        "issue_number": issue_number,
+        "repository": repo,
+        "duplicates": duplicates
+    })
+
+if __name__ == "__main__":
+    logger.info("MCP server started on stdio")
+    # Could also use 'sse' transport, host="0.0.0.0" required for Cloud Run.
+    asyncio.run(
+        mcp.run_async(
+            transport="stdio",
+        )
+    )

--- a/scripts/issue-deduplication/requirements.txt
+++ b/scripts/issue-deduplication/requirements.txt
@@ -1,0 +1,7 @@
+google-genai
+numpy
+tqdm
+scikit-learn
+google-cloud-alloydb-connector[pg8000]
+sqlalchemy
+fastmcp==2.6.1

--- a/scripts/issue-deduplication/setup_alloydb.sh
+++ b/scripts/issue-deduplication/setup_alloydb.sh
@@ -198,7 +198,8 @@ echo ""
 
 # Verify gcloud authentication
 print_info "Verifying gcloud authentication..."
-if ! gcloud auth list --filter=status:ACTIVE --format="value(account)" | grep -q '.'; then
+active_account=$(gcloud auth list --filter=status:ACTIVE --format="value(account)")
+if [[ -z "${active_account}" ]]; then
     print_error "No active gcloud authentication found. Please run 'gcloud auth login'."
     exit 1
 fi
@@ -346,7 +347,8 @@ fi
 # Add the service account as an IAM database user if specified
 if [[ -n "${SA_EMAIL}" ]]; then
     print_header "Step 4.1: Granting Service Account IAM Database Access"
-    if ! gcloud alloydb users list --filter=name:"${SA_EMAIL}" --cluster="${CLUSTER}" --region="${REGION}" --project="${PROJECT_ID}" --format="value(name)" | grep -q '.'; then
+    iam_user=$(gcloud alloydb users list --filter=name:"${SA_EMAIL}" --cluster="${CLUSTER}" --region="${REGION}" --project="${PROJECT_ID}" --format="value(name)")
+    if [[ -z "${iam_user}" ]]; then
         print_info "Granting IAM database access to service account '${SA_EMAIL}'..."
         gcloud alloydb users create "${SA_EMAIL}" \
             --cluster="${CLUSTER}" \

--- a/scripts/issue-deduplication/setup_alloydb.sh
+++ b/scripts/issue-deduplication/setup_alloydb.sh
@@ -1,0 +1,396 @@
+#!/usr/bin/env bash
+
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# AlloyDB Setup Script
+# This script automates the setup of a Google Cloud AlloyDB cluster and instance.
+
+set -e
+
+# --- Colors for output ---
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# --- Helper functions ---
+print_info() {
+    echo -e "${BLUE}ℹ️  $1${NC}"
+}
+
+print_success() {
+    echo -e "${GREEN}✅ $1${NC}"
+}
+
+print_warning() {
+    echo -e "${YELLOW}⚠️  $1${NC}"
+}
+
+print_error() {
+    echo -e "${RED}❌ $1${NC}"
+}
+
+print_header() {
+    echo -e "\n${BLUE}======================================================================${NC}"
+    echo -e "${BLUE} $1${NC}"
+    echo -e "${BLUE}======================================================================${NC}"
+}
+
+# --- Default values ---
+PROJECT_ID="gc-demo-463422"
+REGION="us-central1"
+CLUSTER="issues-embeddings-cluster"
+INSTANCE="primary-instance"
+DB_NAME="postgres"
+DB_PASSWORD=""
+VPC_NETWORK="default"
+SERVICE_ACCOUNT=""
+PRINCIPAL_SET=""
+IP_ADDRESS=""
+
+# --- Show help ---
+show_help() {
+    cat << EOF
+AlloyDB Setup Script
+
+This script sets up a new AlloyDB cluster, a primary instance, and configures it for use.
+
+USAGE:
+    $0 [OPTIONS]
+
+OPTIONS:
+    -p, --project PROJECT_ID    Google Cloud project ID (default: ${PROJECT_ID})
+    -r, --region REGION         Google Cloud region for the AlloyDB cluster (default: ${REGION})
+    -c, --cluster NAME          AlloyDB cluster name (default: ${CLUSTER})
+    -i, --instance NAME         AlloyDB primary instance name (default: ${INSTANCE})
+    -n, --network NAME          VPC network to use (default: ${VPC_NETWORK})
+    --db-name DBNAME            Name for the initial database (default: ${DB_NAME})
+    --db-password PASSWORD      Required: Password for the 'postgres' user
+    -s, --service-account NAME  Service account to create and/or grant AlloyDB client role
+    --principal-set PRINCIPAL   Workload Identity Federation principalSet (eg. principalSet://iam.googleapis.com/..)
+    --ip-address CIDR           Optional: Public IP address range (CIDR) to allow connections from.
+    -h, --help                  Show this help
+
+EXAMPLES:
+    # Run with default settings (recommended)
+    $0
+
+    # Specify a different project and region
+    $0 --project my-other-project --region us-east1
+
+    # Create a service account and grant it access
+    $0 --service-account my-service-account
+
+    # Use Workload Identity Federation
+    $0 --service-account my-sa --principal-set "principal://iam.googleapis.com/projects/123/locations/global/workloadIdentityPools/my-pool/subject/my-subject"
+EOF
+}
+
+# --- Parse command line arguments ---
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -p|--project)
+            PROJECT_ID="$2"
+            shift 2
+            ;;
+        -r|--region)
+            REGION="$2"
+            shift 2
+            ;;
+        -c|--cluster)
+            CLUSTER="$2"
+            shift 2
+            ;;
+        -i|--instance)
+            INSTANCE="$2"
+            shift 2
+            ;;
+        -n|--network)
+            VPC_NETWORK="$2"
+            shift 2
+            ;;
+        --db-name)
+            DB_NAME="$2"
+            shift 2
+            ;;
+        --db-password)
+            DB_PASSWORD="$2"
+            shift 2
+            ;;
+        -s|--service-account)
+            SERVICE_ACCOUNT="$2"
+            shift 2
+            ;;
+        --principal-set)
+            PRINCIPAL_SET="$2"
+            shift 2
+            ;;
+        --ip-address)
+            IP_ADDRESS="$2"
+            shift 2
+            ;;
+        -h|--help)
+            show_help
+            exit 0
+            ;;
+        *)
+            print_error "Unknown option: $1"
+            echo "Use --help for usage information."
+            exit 1
+            ;;
+    esac
+done
+
+# --- Initial validation and configuration ---
+print_header "Starting AlloyDB Setup"
+
+# Validate required arguments
+if [[ -z "${DB_PASSWORD}" ]]; then
+    print_error "Default 'postgres' user password (--db-password) is required."
+    exit 1
+fi
+
+# Check for required arguments based on IP address presence
+if [[ -z "${IP_ADDRESS}" && -z "${SERVICE_ACCOUNT}" ]]; then
+    print_error "When no public IP address is specified (--ip-address), a service account (--service-account) must be provided for authentication via the AlloyDB Auth Proxy."
+    exit 1
+fi
+
+# Auto-detect project ID if not provided via flag or default
+if [[ -z "${PROJECT_ID}" ]]; then
+    print_info "Auto-detecting Google Cloud project..."
+    PROJECT_ID=$(gcloud config get-value project 2>/dev/null)
+    if [[ -z "${PROJECT_ID}" ]]; then
+        print_error "Could not auto-detect Google Cloud project ID."
+        echo "Please use the --project flag or run 'gcloud config set project YOUR_PROJECT_ID'"
+        exit 1
+    fi
+fi
+
+# Print configuration that will be used
+echo "Using the following configuration:"
+echo "  ☁️ Project:         ${PROJECT_ID}"
+echo "  📍 Region:          ${REGION}"
+echo "  🔗 VPC Network:     ${VPC_NETWORK}"
+echo "  🗄️  Cluster Name:    ${CLUSTER}"
+echo "  🖥️  Instance Name:   ${INSTANCE}"
+echo "  💾 Database Name:   ${DB_NAME}"
+if [[ -n "${SERVICE_ACCOUNT}" ]]; then
+    echo "  👤 Service Account: ${SERVICE_ACCOUNT}"
+    if [[ -n "${PRINCIPAL_SET}" ]]; then
+        echo "  🌍 Principal Set:   ${PRINCIPAL_SET}"
+    fi
+fi
+echo ""
+
+# Verify gcloud authentication
+print_info "Verifying gcloud authentication..."
+if ! gcloud auth list --filter=status:ACTIVE --format="value(account)" | grep -q '.'; then
+    print_error "No active gcloud authentication found. Please run 'gcloud auth login'."
+    exit 1
+fi
+
+# Test project access
+if ! gcloud projects describe "${PROJECT_ID}" > /dev/null 2>&1; then
+    print_error "Cannot access project '${PROJECT_ID}'. Please verify the ID and your permissions."
+    exit 1
+fi
+print_success "Authentication and project access verified."
+
+
+# --- Step 1: Enable required APIs ---
+print_header "Step 1: Enabling required Google Cloud APIs"
+apis_to_enable=(
+    "alloydb.googleapis.com"
+    "compute.googleapis.com"
+    "servicenetworking.googleapis.com"
+    "cloudresourcemanager.googleapis.com"
+    "iam.googleapis.com"
+)
+
+print_info "Checking and enabling APIs: ${apis_to_enable[*]}"
+gcloud services enable "${apis_to_enable[@]}" --project="${PROJECT_ID}"
+print_success "APIs enabled successfully."
+
+
+# --- Step 2: Configure Service Account (if specified) ---
+if [[ -n "${SERVICE_ACCOUNT}" ]]; then
+    print_header "Step 2: Configuring Service Account"
+    SA_EMAIL="${SERVICE_ACCOUNT}@${PROJECT_ID}.iam.gserviceaccount.com"
+    
+    print_info "Checking if service account '${SERVICE_ACCOUNT}' exists..."
+    if ! gcloud iam service-accounts describe "${SA_EMAIL}" --project="${PROJECT_ID}" &> /dev/null; then
+        print_warning "Service account not found. Creating it..."
+        gcloud iam service-accounts create "${SERVICE_ACCOUNT}" \
+            --display-name="${SERVICE_ACCOUNT}" \
+            --project="${PROJECT_ID}"
+        print_success "Service account '${SERVICE_ACCOUNT}' created."
+    else
+        print_success "Service account '${SERVICE_ACCOUNT}' already exists."
+    fi
+
+    print_info "Assigning 'roles/serviceusage.serviceUsageConsumer' to service account..."
+    gcloud projects add-iam-policy-binding "${PROJECT_ID}" \
+        --member="serviceAccount:${SA_EMAIL}" \
+        --role="roles/serviceusage.serviceUsageConsumer" --quiet --condition=None > /dev/null
+    print_success "Role 'roles/serviceusage.serviceUsageConsumer' assigned."
+
+    print_info "Assigning 'roles/alloydb.client' to service account..."
+    gcloud projects add-iam-policy-binding "${PROJECT_ID}" \
+        --member="serviceAccount:${SA_EMAIL}" \
+        --role="roles/alloydb.client" --quiet --condition=None > /dev/null
+    print_success "Role 'roles/alloydb.client' assigned."
+
+    print_info "Assigning 'roles/alloydb.databaseUser' to service account..."
+    gcloud projects add-iam-policy-binding "${PROJECT_ID}" \
+        --member="serviceAccount:${SA_EMAIL}" \
+        --role="roles/alloydb.databaseUser" --quiet --condition=None > /dev/null
+    print_success "Role 'roles/alloydb.databaseUser' assigned."
+
+    print_info "Assigning 'roles/iam.serviceAccountTokenCreator' to service account on itself..."
+    gcloud iam service-accounts add-iam-policy-binding "${SA_EMAIL}" \
+        --project="${PROJECT_ID}" \
+        --role="roles/iam.serviceAccountTokenCreator" \
+        --member="serviceAccount:${SA_EMAIL}" --quiet --condition=None > /dev/null
+    print_success "Role 'roles/iam.serviceAccountTokenCreator' assigned."
+
+    if [[ -n "${PRINCIPAL_SET}" ]]; then
+        print_info "Assigning 'roles/iam.workloadIdentityUser' to principal set..."
+        gcloud iam service-accounts add-iam-policy-binding "${SA_EMAIL}" \
+            --project="${PROJECT_ID}" \
+            --role="roles/iam.workloadIdentityUser" \
+            --member="${PRINCIPAL_SET}" --quiet > /dev/null
+        print_success "Workload Identity User role granted to principal."
+    else
+        print_info "No workload identify federation principal set specified, skipping role assignment."
+    fi
+else
+    print_info "No service account specified, skipping service account configuration."
+fi
+
+# --- Step 3: Create AlloyDB Cluster ---
+print_header "Step 3: Creating AlloyDB Cluster"
+if ! gcloud alloydb clusters describe "${CLUSTER}" --region="${REGION}" --project="${PROJECT_ID}" &> /dev/null; then
+    print_info "Creating AlloyDB cluster '${CLUSTER}'..."
+    gcloud alloydb clusters create "${CLUSTER}" \
+        --password="${DB_PASSWORD}" \
+        --region="${REGION}" \
+        --network="${VPC_NETWORK}" \
+        --project="${PROJECT_ID}"
+    print_success "AlloyDB cluster created."
+else
+    print_success "AlloyDB cluster '${CLUSTER}' already exists."
+fi
+
+
+# --- Step 4: Create Primary AlloyDB Instance ---
+print_header "Step 4: Creating Primary AlloyDB Instance"
+if ! gcloud alloydb instances describe "${INSTANCE}" --cluster="${CLUSTER}" --region="${REGION}" --project="${PROJECT_ID}" &> /dev/null; then
+    print_info "Creating primary instance '${INSTANCE}'. This may take a few minutes..."
+    
+    INSTANCE_CREATE_CMD=(gcloud alloydb instances create "${INSTANCE}"
+        --cluster="${CLUSTER}"
+        --region="${REGION}"
+        --instance-type=PRIMARY
+        --cpu-count=2
+        --project="${PROJECT_ID}"
+        --availability-type=ZONAL
+        --assign-inbound-public-ip=ASSIGN_IPV4
+    )
+
+    # Add public IP configuration if specified
+    if [[ -n "${IP_ADDRESS}" ]]; then
+        print_warning "Assigning a public IP and allowing access from '${IP_ADDRESS}'."
+        INSTANCE_CREATE_CMD+=(
+            --authorized-external-networks="${IP_ADDRESS}"
+        )
+    else
+        print_info "No public IP address specified. The instance will only be accessible within the VPC."
+    fi
+
+    # Enable IAM database authentication if a service account email is provided
+    if [[ -n "${SA_EMAIL}" ]]; then
+        print_info "Enabling IAM database authentication for the instance."
+        INSTANCE_CREATE_CMD+=(
+            "--database-flags=password.enforce_complexity=on,alloydb.iam_authentication=on"
+        )
+    else
+        INSTANCE_CREATE_CMD+=(
+            "--database-flags=password.enforce_complexity=on"
+        )
+    fi
+
+    # Execute the create command
+    "${INSTANCE_CREATE_CMD[@]}"
+    print_success "Primary instance created."
+else
+    print_success "Primary instance '${INSTANCE}' already exists."
+    # Note: This script doesn't modify the flags of an existing instance.
+    # If the instance exists but doesn't have IAM auth enabled, you would need to run
+    # 'gcloud alloydb instances update' to add the database flag.
+fi
+
+# Add the service account as an IAM database user if specified
+if [[ -n "${SA_EMAIL}" ]]; then
+    print_header "Step 4.1: Granting Service Account IAM Database Access"
+    if ! gcloud alloydb users list --filter=name:"${SA_EMAIL}" --cluster="${CLUSTER}" --region="${REGION}" --project="${PROJECT_ID}" --format="value(name)" | grep -q '.'; then
+        print_info "Granting IAM database access to service account '${SA_EMAIL}'..."
+        gcloud alloydb users create "${SA_EMAIL}" \
+            --cluster="${CLUSTER}" \
+            --region="${REGION}" \
+            --project="${PROJECT_ID}" \
+            --type=IAM_BASED \
+            --db-roles=postgres
+        print_success "IAM user for service account created."
+    else
+        print_success "IAM user for '${SA_EMAIL}' already exists."
+    fi
+fi
+
+# --- Step 5: Final Output ---
+print_header "🎉 Setup Complete! 🎉"
+
+print_info "Fetching instance IP address..."
+INSTANCE_IP=$(gcloud alloydb instances describe "${INSTANCE}" --cluster="${CLUSTER}" --region="${REGION}" --project="${PROJECT_ID}" --format='value(publicIpAddress)')
+
+if [[ -z "${INSTANCE_IP}" ]]; then
+    print_error "Could not retrieve the instance IP address."
+    exit 1
+fi
+
+echo ""
+print_success "Setup completed successfully!"
+
+
+# --- Step 6: Output Configuration ---
+print_header "Output Settings:"
+echo "  PROJECT_ID: ${PROJECT_ID}"
+echo "  REGION: ${REGION}"
+echo "  CLUSTER_ID: ${CLUSTER}"
+echo "  INSTANCE_ID: ${INSTANCE}"
+echo "  DATABASE_NAME: ${DB_NAME}"
+echo "  DB_USER: postgres"
+echo "  INSTANCE_HOST: ${INSTANCE_IP}"
+echo ""
+
+if [[ -n "${IP_ADDRESS}" ]]; then
+    print_info "Access configured to allow connections from IP address ${IP_ADDRESS}"
+else
+    print_info "Connect using AlloyDB proxy through service account ${SA_EMAIL}"
+fi
+
+echo ""
+print_success "All steps completed!"

--- a/scripts/setup_workload_identity.sh
+++ b/scripts/setup_workload_identity.sh
@@ -344,6 +344,7 @@ print_header "🎉 Setup Complete!"
 echo ""
 print_success "Direct Workload Identity Federation has been configured for your repository!"
 echo ""
+echo "Configured principal set - ${PRINCIPAL_SET}"
 
 print_header "Permissions Granted"
 echo ""

--- a/workflows/issue-triage/README.md
+++ b/workflows/issue-triage/README.md
@@ -8,6 +8,10 @@ This document describes a comprehensive system for triaging GitHub issues using 
   - [Workflows in Detail](#workflows-in-detail)
     - [Real-Time Issue Triage](#real-time-issue-triage)
     - [Scheduled Issue Triage](#scheduled-issue-triage)
+  - [Issue Deduplication](#issue-deduplication)
+    - [Overview](#overview)
+    - [How it Works](#how-it-works-1)
+    - [Setup](#setup)
 
 
 ## How it Works
@@ -76,3 +80,23 @@ This workflow is defined in `workflows/issue-triage/gemini-issue-automated-triag
 ### Scheduled Issue Triage
 
 This workflow is defined in `workflows/issue-triage/gemini-issue-scheduled-triage.yml` and runs on a schedule (e.g., every hour). It finds any issues that have no labels or have the `status/needs-triage` label and then uses the Gemini CLI to triage them. This workflow can also be manually triggered.
+
+## Issue Deduplication
+
+### Overview
+
+The issue triage system includes an advanced feature for detecting and reporting duplicate issues. This system uses a custom MCP server backed by an AlloyDB database to store issue embeddings and find similarities between them.
+
+### How it Works
+
+The deduplication process involves two key workflows:
+
+1.  **Real-time Duplicate Detection**: When a new issue is created, the `deduplicate-issues` job in the `gemini-issue-automated-triage.yml` workflow is triggered. This job uses the `duplicates` tool from the MCP server to find semantically similar issues. If any potential duplicates are found, the workflow will post a comment on the new issue listing the possible duplicates. This job can also be triggered manually by commenting `@gemini-cli /deduplicate` on an issue.
+
+2.  **Scheduled Embedding Refresh**: To keep the database of issue embeddings current, the `refresh-embeddings` job in the `gemini-issue-scheduled-triage.yml` workflow runs on a schedule. This job uses the `refresh` tool of the MCP server to process all open issues and update their corresponding embeddings in the AlloyDB database.
+
+### Setup
+
+Setting up the issue deduplication feature requires a Google Cloud project and an AlloyDB database.
+
+For detailed instructions on how to set up the necessary cloud resources and configure the workflows, please refer to the guide at [scripts/issue-deduplication/README.md](../../scripts/issue-deduplication/README.md). This guide provides step-by-step instructions for using the `setup_alloydb.sh` script and configuring the necessary secrets and variables in your GitHub repository.

--- a/workflows/issue-triage/gemini-issue-automated-triage.yml
+++ b/workflows/issue-triage/gemini-issue-automated-triage.yml
@@ -115,7 +115,6 @@ jobs:
             - Reference all shell variables as "${VAR}" (with quotes and braces)
 
   deduplicate-issues:
-    needs: triage-issue
     if: >
       vars.ALLOYDB_INSTANCE_CONNECTION_NAME &&
       (github.event_name == 'issues' ||
@@ -223,6 +222,7 @@ jobs:
                 }
               },
               "coreTools": [
+                "run_shell_command(echo)",
                 "run_shell_command(gh issue comment)",
                 "run_shell_command(gh issue view)",
                 "run_shell_command(gh issue edit)"
@@ -247,6 +247,7 @@ jobs:
                 - The repository is ${{ github.repository }} and the issue number is ${{ github.event.issue.number }}.
                 - Use the `duplicates` tool with the `repo` and `issue_number` to find potential duplicates for the current issue. Do not use the `threshold` parameter.
                 - If no duplicates are found, you are done.
+                - Print the JSON output from the `duplicates` tool to the logs.
 
             2.  **Refine Duplicates List (if necessary):**
                 - If the `duplicates` tool returns between 1 and 14 results, you must refine the list.
@@ -255,6 +256,7 @@ jobs:
                 - Carefully analyze the content (title, body, comments) of the original issue and all potential duplicates.
                 - Based on your analysis, create a final list containing only the issues you are highly confident are actual duplicates.
                 - If your final list is empty, you are done.
+                - Print to the logs if you omitted any potential duplicates based on your analysis.
                 - If the `duplicates` tool returned 15+ results, use the top 15 matches (based on descending similarity score value) to perform this step.
 
             3.  **Format Final Duplicates List:**

--- a/workflows/issue-triage/gemini-issue-automated-triage.yml
+++ b/workflows/issue-triage/gemini-issue-automated-triage.yml
@@ -138,18 +138,20 @@ jobs:
           app-id: '${{ vars.APP_ID }}'
           private-key: '${{ secrets.APP_PRIVATE_KEY }}'
 
-      - id: 'auth'
+      - name: 'Authenticate to Google Cloud'
+        id: 'auth'
         uses: 'google-github-actions/auth@140bb5113ffb6b65a7e9b937a81fa96cf5064462' # ratchet:google-github-actions/auth@v2
         with:
+          token_format: 'access_token'
           workload_identity_provider: '${{ vars.GCP_WIF_PROVIDER }}'
           service_account: '${{ vars.SERVICE_ACCOUNT_EMAIL }}'
 
-      - name: 'Set up Cloud SDK'
-        uses: 'google-github-actions/setup-gcloud@6189d56e4096ee891640bb02ac264be376592d6a' # ratchet:google-github-actions/setup-gcloud@v2
-
-      - name: 'Configure Docker for Artifact Registry'
-        run: |-
-          gcloud auth configure-docker northamerica-northeast1-docker.pkg.dev
+      - name: 'Login to GAR'
+        uses: 'docker/login-action@v3'
+        with:
+          registry: 'northamerica-northeast1-docker.pkg.dev'
+          username: 'oauth2accesstoken'
+          password: '${{ steps.auth.outputs.access_token }}'
 
       - name: 'Download AlloyDB Auth Proxy'
         run: |

--- a/workflows/issue-triage/gemini-issue-automated-triage.yml
+++ b/workflows/issue-triage/gemini-issue-automated-triage.yml
@@ -70,6 +70,8 @@ jobs:
           GOOGLE_CLOUD_PROJECT: '${{ vars.GOOGLE_CLOUD_PROJECT }}'
           GOOGLE_CLOUD_LOCATION: '${{ vars.GOOGLE_CLOUD_LOCATION }}'
           GOOGLE_GENAI_USE_VERTEXAI: '${{ vars.GOOGLE_GENAI_USE_VERTEXAI }}'
+          GOOGLE_GENAI_USE_GCA: '${{ vars.GOOGLE_GENAI_USE_GCA }}'
+          SERVICE_ACCOUNT_EMAIL: '${{ vars.SERVICE_ACCOUNT_EMAIL }}'
         with:
           settings: |-
             {
@@ -110,4 +112,168 @@ jobs:
             - Do not add comments or modify the issue content
             - Triage only the current issue
             - Assign all applicable labels based on the issue content
+            - Reference all shell variables as "${VAR}" (with quotes and braces)
+
+  deduplicate-issues:
+    needs: triage-issue
+    if: >
+      github.event_name == 'issues' ||
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'issue_comment' &&
+       contains(github.event.comment.body, '@gemini-cli /deduplicate') &&
+       (github.event.comment.author_association == 'OWNER' ||
+        github.event.comment.author_association == 'MEMBER' ||
+        github.event.comment.author_association == 'COLLABORATOR'))
+    timeout-minutes: 5
+    runs-on: 'ubuntu-latest'
+
+    steps:
+      - name: 'Checkout repository'
+        uses: 'actions/checkout@v4'
+
+      - name: 'Generate GitHub App Token'
+        id: 'generate_token'
+        if: |-
+          ${{ vars.APP_ID }}
+        uses: 'actions/create-github-app-token@v1'
+        with:
+          app-id: '${{ vars.APP_ID }}'
+          private-key: '${{ secrets.APP_PRIVATE_KEY }}'
+
+      - id: 'auth'
+        uses: 'google-github-actions/auth@v2'
+        with:
+          workload_identity_provider: '${{ vars.GCP_WIF_PROVIDER }}'
+          service_account: '${{ vars.SERVICE_ACCOUNT_EMAIL }}'
+
+      - name: 'Set up Cloud SDK'
+        uses: 'google-github-actions/setup-gcloud@v2'
+
+      - name: 'Configure Docker for Artifact Registry'
+        run: gcloud auth configure-docker northamerica-northeast1-docker.pkg.dev
+
+      - name: 'Download AlloyDB Auth Proxy'
+        run: |
+          curl -o alloydb-auth-proxy https://storage.googleapis.com/alloydb-auth-proxy/v1.13.4/alloydb-auth-proxy.linux.amd64
+          chmod +x alloydb-auth-proxy
+
+      - name: 'Start AlloyDB Auth Proxy'
+        run: ./alloydb-auth-proxy "${{ vars.ALLOYDB_INSTANCE_CONNECTION_NAME }}" --public-ip -i --impersonate-service-account ${{ vars.SERVICE_ACCOUNT_EMAIL }} &
+
+      - name: 'Run Gemini Issue Deduplication'
+        uses: 'google-github-actions/run-gemini-cli@main'
+        env:
+          GITHUB_TOKEN: '${{ steps.generate_token.outputs.token || secrets.GITHUB_TOKEN }}'
+          ISSUE_NUMBER: '${{ github.event.issue.number }}'
+          REPOSITORY: '${{ github.repository }}'
+          GEMINI_CLI_VERSION: '${{ vars.GEMINI_CLI_VERSION }}'
+          OTLP_GOOGLE_CLOUD_PROJECT: '${{ vars.OTLP_GOOGLE_CLOUD_PROJECT }}'
+          GCP_WIF_PROVIDER: '${{ vars.GCP_WIF_PROVIDER }}'
+          GEMINI_API_KEY: '${{ secrets.GEMINI_API_KEY }}'
+          GOOGLE_CLOUD_PROJECT: '${{ vars.GOOGLE_CLOUD_PROJECT }}'
+          GOOGLE_CLOUD_LOCATION: '${{ vars.GOOGLE_CLOUD_LOCATION }}'
+          GOOGLE_GENAI_USE_VERTEXAI: '${{ vars.GOOGLE_GENAI_USE_VERTEXAI }}'
+          DB_PASS: '${{ secrets.ALLOYDB_DB_PASS }}'
+          INSTANCE_HOST: '127.0.0.1'
+          INSTANCE_PORT: '5432'
+        with:
+          settings: |-
+            {
+              "mcpServers": {
+                "issue_deduplication": {
+                  "command": "docker",
+                  "args": [
+                    "run",
+                    "-i",
+                    "--rm",
+                    "--network=host",
+                    "-e",
+                    "GITHUB_TOKEN",
+                    "-e",
+                    "GEMINI_API_KEY",
+                    "-e",
+                    "DB_USER",
+                    "-e",
+                    "DB_PASS",
+                    "-e",
+                    "INSTANCE_HOST",
+                    "-e",
+                    "INSTANCE_PORT",
+                    "northamerica-northeast1-docker.pkg.dev/quacktastic-waffle/run-gemini-cli/issues-dedup-mcp-server:latest"
+                  ],
+                  "env": {
+                    "GITHUB_TOKEN": "${GITHUB_TOKEN}",
+                    "GEMINI_API_KEY": "${GEMINI_API_KEY}",
+                    "DB_USER": "${DB_USER}",
+                    "DB_PASS": "${DB_PASS}",
+                    "INSTANCE_HOST": "${INSTANCE_HOST}",
+                    "INSTANCE_PORT": "${INSTANCE_PORT}"
+                  },
+                  "enabled": true
+                }
+              },
+              "coreTools": [
+                "run_shell_command(gh issue comment)",
+                "run_shell_command(gh issue view)"
+              ],
+              "telemetry": {
+                "enabled": true,
+                "target": "gcp"
+              },
+              "sandbox": false
+            }
+          prompt: |-
+            ## Role
+
+            You are an issue de-duplication assistant. Your goal is to find
+            duplicate issues and notify the user by commenting on the current
+            issue, while avoiding duplicate comments.
+
+            ## Steps
+
+            1.  **Find Potential Duplicates:**
+                - The full repository name is available in the `${REPOSITORY}` environment variable (e.g., "owner/repo"). You will need to parse this to get the `repo_owner` and `repo_name`.
+                - The issue number is available in the `${ISSUE_NUMBER}` environment variable.
+                - Use the `duplicates` tool with the `repo_owner`, `repo_name`, and `issue_number` to find potential duplicates for the current issue. Do not use the `threshold` parameter.
+                - If no duplicates are found, you are done.
+
+            2.  **Refine Duplicates List (if necessary):**
+                - If the `duplicates` tool returns between 1 and 14 results, you must refine the list.
+                - For each potential duplicate issue, run `gh issue view <issue-number> --json title,body,comments` to fetch its content.
+                - Also fetch the content of the original issue: `gh issue view "${ISSUE_NUMBER}" --json title,body,comments`.
+                - Carefully analyze the content (title, body, comments) of the original issue and all potential duplicates.
+                - Based on your analysis, create a final list containing only the issues you are highly confident are actual duplicates.
+                - If your final list is empty, you are done.
+                - If the `duplicates` tool returned 15+ results, use the top 15 matches (based on descending similarity score value) to perform this step.
+
+            3.  **Format Final Duplicates List:**
+                Format the final list of duplicates into a markdown string.
+                The format should be:
+                "Found possible duplicate issues:\n\n- #${issue_number}: ${issue_title}"
+                Add an HTML comment to the end for identification: `<!-- gemini-cli-deduplication -->`
+
+            4.  **Check for Existing Comment:**
+                - Run `gh issue view "${ISSUE_NUMBER}" --json comments` to get all
+                  comments on the issue.
+                - Look for a comment made by a bot (the author's login often ends in `[bot]`) that contains `<!-- gemini-cli-deduplication -->`.
+                - If you find such a comment, store its `id` and `body`.
+
+            5.  **Decide Action:**
+                - **If an existing comment is found:**
+                    - Compare the new list of duplicate issues with the list from the existing comment's body.
+                    - If they are the same, do nothing.
+                    - If they are different, edit the existing comment. Use
+                      `gh issue comment "${ISSUE_NUMBER}" --edit-comment <comment-id> --body "..."`.
+                      The new body should be the new list of duplicates, but with the header "Found possible duplicate issues (updated):".
+                - **If no existing comment is found:**
+                    - Create a new comment with the list of duplicates.
+                    - Use `gh issue comment "${ISSUE_NUMBER}" --body "..."`.
+
+            ## Guidelines
+
+            - Only use the `duplicates` and `run_shell_command` tools.
+            - The `run_shell_command` tool can be used with `gh issue view` and `gh issue comment`.
+            - Do not download or read media files like images, videos, or links. The `--json` flag for `gh issue view` will prevent this.
+            - Do not modify the issue content, labels, or status.
+            - Only comment on the current issue.
             - Reference all shell variables as "${VAR}" (with quotes and braces)

--- a/workflows/issue-triage/gemini-issue-automated-triage.yml
+++ b/workflows/issue-triage/gemini-issue-automated-triage.yml
@@ -141,16 +141,17 @@ jobs:
           private-key: '${{ secrets.APP_PRIVATE_KEY }}'
 
       - id: 'auth'
-        uses: 'google-github-actions/auth@v2'
+        uses: 'google-github-actions/auth@140bb5113ffb6b65a7e9b937a81fa96cf5064462' # ratchet:google-github-actions/auth@v2
         with:
           workload_identity_provider: '${{ vars.GCP_WIF_PROVIDER }}'
           service_account: '${{ vars.SERVICE_ACCOUNT_EMAIL }}'
 
       - name: 'Set up Cloud SDK'
-        uses: 'google-github-actions/setup-gcloud@v2'
+        uses: 'google-github-actions/setup-gcloud@6189d56e4096ee891640bb02ac264be376592d6a' # ratchet:google-github-actions/setup-gcloud@v2
 
       - name: 'Configure Docker for Artifact Registry'
-        run: gcloud auth configure-docker northamerica-northeast1-docker.pkg.dev
+        run: |-
+          gcloud auth configure-docker northamerica-northeast1-docker.pkg.dev
 
       - name: 'Download AlloyDB Auth Proxy'
         run: |
@@ -158,7 +159,8 @@ jobs:
           chmod +x alloydb-auth-proxy
 
       - name: 'Start AlloyDB Auth Proxy'
-        run: ./alloydb-auth-proxy "${{ vars.ALLOYDB_INSTANCE_CONNECTION_NAME }}" --public-ip -i --impersonate-service-account ${{ vars.SERVICE_ACCOUNT_EMAIL }} &
+        run: |-
+          ./alloydb-auth-proxy "${{ vars.ALLOYDB_INSTANCE_CONNECTION_NAME }}" --public-ip -i --impersonate-service-account ${{ vars.SERVICE_ACCOUNT_EMAIL }} &
 
       - name: 'Test AlloyDB Auth Proxy'
         env:

--- a/workflows/issue-triage/gemini-issue-automated-triage.yml
+++ b/workflows/issue-triage/gemini-issue-automated-triage.yml
@@ -48,7 +48,8 @@ jobs:
 
       - name: 'Generate GitHub App Token'
         id: 'generate_token'
-        if: vars.APP_ID != ''
+        if: |-
+          ${{ vars.APP_ID != '' }}
         uses: 'actions/create-github-app-token@v1'
         with:
           app-id: '${{ vars.APP_ID }}'
@@ -132,7 +133,8 @@ jobs:
 
       - name: 'Generate GitHub App Token'
         id: 'generate_token'
-        if: vars.APP_ID != ''
+        if: |-
+          ${{ vars.APP_ID  != '' }}
         uses: 'actions/create-github-app-token@v1'
         with:
           app-id: '${{ vars.APP_ID }}'

--- a/workflows/issue-triage/gemini-issue-automated-triage.yml
+++ b/workflows/issue-triage/gemini-issue-automated-triage.yml
@@ -117,13 +117,14 @@ jobs:
   deduplicate-issues:
     needs: triage-issue
     if: >
-      github.event_name == 'issues' ||
+      vars.ALLOYDB_INSTANCE_CONNECTION_NAME &&
+      (github.event_name == 'issues' ||
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'issue_comment' &&
        contains(github.event.comment.body, '@gemini-cli /deduplicate') &&
        (github.event.comment.author_association == 'OWNER' ||
         github.event.comment.author_association == 'MEMBER' ||
-        github.event.comment.author_association == 'COLLABORATOR'))
+        github.event.comment.author_association == 'COLLABORATOR')))
     timeout-minutes: 10
     runs-on: 'ubuntu-latest'
 

--- a/workflows/issue-triage/gemini-issue-automated-triage.yml
+++ b/workflows/issue-triage/gemini-issue-automated-triage.yml
@@ -174,8 +174,6 @@ jobs:
           GITHUB_TOKEN: '${{ steps.generate_token.outputs.token || secrets.GITHUB_TOKEN }}'
           ISSUE_NUMBER: '${{ github.event.issue.number }}'
           REPOSITORY: '${{ github.repository }}'
-          REPO_OWNER: '${{ github.repository_owner }}'
-          REPO_NAME: '${{ github.event.repository.name }}'
           GEMINI_CLI_VERSION: '${{ vars.GEMINI_CLI_VERSION }}'
           OTLP_GOOGLE_CLOUD_PROJECT: '${{ vars.OTLP_GOOGLE_CLOUD_PROJECT }}'
           GCP_WIF_PROVIDER: '${{ vars.GCP_WIF_PROVIDER }}'
@@ -244,8 +242,8 @@ jobs:
             ## Steps
 
             1.  **Find Potential Duplicates:**
-                - The repo_owner/repo_name is ${{ github.repository }} and the issue number is ${{ github.event.issue.number }}.
-                - Use the `duplicates` tool with the `repo_owner`, `repo_name`, and `issue_number` to find potential duplicates for the current issue. Do not use the `threshold` parameter.
+                - The repository is ${{ github.repository }} and the issue number is ${{ github.event.issue.number }}.
+                - Use the `duplicates` tool with the `repo` and `issue_number` to find potential duplicates for the current issue. Do not use the `threshold` parameter.
                 - If no duplicates are found, you are done.
 
             2.  **Refine Duplicates List (if necessary):**

--- a/workflows/issue-triage/gemini-issue-automated-triage.yml
+++ b/workflows/issue-triage/gemini-issue-automated-triage.yml
@@ -124,7 +124,7 @@ jobs:
        (github.event.comment.author_association == 'OWNER' ||
         github.event.comment.author_association == 'MEMBER' ||
         github.event.comment.author_association == 'COLLABORATOR'))
-    timeout-minutes: 5
+    timeout-minutes: 10
     runs-on: 'ubuntu-latest'
 
     steps:
@@ -160,12 +160,21 @@ jobs:
       - name: 'Start AlloyDB Auth Proxy'
         run: ./alloydb-auth-proxy "${{ vars.ALLOYDB_INSTANCE_CONNECTION_NAME }}" --public-ip -i --impersonate-service-account ${{ vars.SERVICE_ACCOUNT_EMAIL }} &
 
+      - name: 'Test AlloyDB Auth Proxy'
+        env:
+          DB_USER: 'postgres'
+          DB_PASS: '${{ secrets.ALLOYDB_DB_PASS }}'
+        run: |
+          PGPASSWORD=$DB_PASS psql "host=127.0.0.1 port=5432 user=$DB_USER dbname=postgres  sslmode=disable" --command="SELECT 1;"
+
       - name: 'Run Gemini Issue Deduplication'
         uses: 'google-github-actions/run-gemini-cli@main'
         env:
           GITHUB_TOKEN: '${{ steps.generate_token.outputs.token || secrets.GITHUB_TOKEN }}'
           ISSUE_NUMBER: '${{ github.event.issue.number }}'
           REPOSITORY: '${{ github.repository }}'
+          REPO_OWNER: '${{ github.repository_owner }}'
+          REPO_NAME: '${{ github.event.repository.name }}'
           GEMINI_CLI_VERSION: '${{ vars.GEMINI_CLI_VERSION }}'
           OTLP_GOOGLE_CLOUD_PROJECT: '${{ vars.OTLP_GOOGLE_CLOUD_PROJECT }}'
           GCP_WIF_PROVIDER: '${{ vars.GCP_WIF_PROVIDER }}'
@@ -173,6 +182,8 @@ jobs:
           GOOGLE_CLOUD_PROJECT: '${{ vars.GOOGLE_CLOUD_PROJECT }}'
           GOOGLE_CLOUD_LOCATION: '${{ vars.GOOGLE_CLOUD_LOCATION }}'
           GOOGLE_GENAI_USE_VERTEXAI: '${{ vars.GOOGLE_GENAI_USE_VERTEXAI }}'
+          SERVICE_ACCOUNT_EMAIL: '${{ vars.SERVICE_ACCOUNT_EMAIL }}'
+          DB_USER: 'postgres'
           DB_PASS: '${{ secrets.ALLOYDB_DB_PASS }}'
           INSTANCE_HOST: '127.0.0.1'
           INSTANCE_PORT: '5432'
@@ -204,7 +215,7 @@ jobs:
                   "env": {
                     "GITHUB_TOKEN": "${GITHUB_TOKEN}",
                     "GEMINI_API_KEY": "${GEMINI_API_KEY}",
-                    "DB_USER": "${DB_USER}",
+                    "DB_USER": "postgres",
                     "DB_PASS": "${DB_PASS}",
                     "INSTANCE_HOST": "${INSTANCE_HOST}",
                     "INSTANCE_PORT": "${INSTANCE_PORT}"
@@ -232,8 +243,7 @@ jobs:
             ## Steps
 
             1.  **Find Potential Duplicates:**
-                - The full repository name is available in the `${REPOSITORY}` environment variable (e.g., "owner/repo"). You will need to parse this to get the `repo_owner` and `repo_name`.
-                - The issue number is available in the `${ISSUE_NUMBER}` environment variable.
+                - The repo_owner/repo_name is ${{ github.repository }} and the issue number is ${{ github.event.issue.number }}.
                 - Use the `duplicates` tool with the `repo_owner`, `repo_name`, and `issue_number` to find potential duplicates for the current issue. Do not use the `threshold` parameter.
                 - If no duplicates are found, you are done.
 

--- a/workflows/issue-triage/gemini-issue-automated-triage.yml
+++ b/workflows/issue-triage/gemini-issue-automated-triage.yml
@@ -48,8 +48,7 @@ jobs:
 
       - name: 'Generate GitHub App Token'
         id: 'generate_token'
-        if: |-
-          ${{ vars.APP_ID }}
+        if: vars.APP_ID != ''
         uses: 'actions/create-github-app-token@v1'
         with:
           app-id: '${{ vars.APP_ID }}'
@@ -116,7 +115,7 @@ jobs:
 
   deduplicate-issues:
     if: >
-      vars.ALLOYDB_INSTANCE_CONNECTION_NAME &&
+      vars.ALLOYDB_INSTANCE_CONNECTION_NAME != '' &&
       (github.event_name == 'issues' ||
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'issue_comment' &&
@@ -133,8 +132,7 @@ jobs:
 
       - name: 'Generate GitHub App Token'
         id: 'generate_token'
-        if: |-
-          ${{ vars.APP_ID }}
+        if: vars.APP_ID != ''
         uses: 'actions/create-github-app-token@v1'
         with:
           app-id: '${{ vars.APP_ID }}'

--- a/workflows/issue-triage/gemini-issue-automated-triage.yml
+++ b/workflows/issue-triage/gemini-issue-automated-triage.yml
@@ -224,7 +224,8 @@ jobs:
               },
               "coreTools": [
                 "run_shell_command(gh issue comment)",
-                "run_shell_command(gh issue view)"
+                "run_shell_command(gh issue view)",
+                "run_shell_command(gh issue edit)"
               ],
               "telemetry": {
                 "enabled": true,
@@ -236,8 +237,9 @@ jobs:
             ## Role
 
             You are an issue de-duplication assistant. Your goal is to find
-            duplicate issues and notify the user by commenting on the current
-            issue, while avoiding duplicate comments.
+            duplicate issues, label the current issue as a duplicate, and notify
+            the user by commenting on the current issue, while avoiding
+            duplicate comments.
 
             ## Steps
 
@@ -278,11 +280,15 @@ jobs:
                     - Create a new comment with the list of duplicates.
                     - Use `gh issue comment "${ISSUE_NUMBER}" --body "..."`.
 
+            6.  **Add Duplicate Label:**
+                - If you created or updated a comment in the previous step, add the `duplicate` label to the current issue.
+                - Use `gh issue edit "${ISSUE_NUMBER}" --add-label "duplicate"`.
+
             ## Guidelines
 
             - Only use the `duplicates` and `run_shell_command` tools.
-            - The `run_shell_command` tool can be used with `gh issue view` and `gh issue comment`.
+            - The `run_shell_command` tool can be used with `gh issue view`, `gh issue comment`, and `gh issue edit`.
             - Do not download or read media files like images, videos, or links. The `--json` flag for `gh issue view` will prevent this.
-            - Do not modify the issue content, labels, or status.
-            - Only comment on the current issue.
+            - Do not modify the issue content or status.
+            - Only comment on and label the current issue.
             - Reference all shell variables as "${VAR}" (with quotes and braces)

--- a/workflows/issue-triage/gemini-issue-scheduled-triage.yml
+++ b/workflows/issue-triage/gemini-issue-scheduled-triage.yml
@@ -123,7 +123,8 @@ jobs:
             - Reference all shell variables as "${VAR}" (with quotes and braces)
 
   refresh-embeddings:
-    if: vars.ALLOYDB_INSTANCE_CONNECTION_NAME
+    if: |-
+      ${{ vars.ALLOYDB_INSTANCE_CONNECTION_NAME }}
     timeout-minutes: 20
     runs-on: 'ubuntu-latest'
     steps:
@@ -140,16 +141,17 @@ jobs:
           private-key: '${{ secrets.APP_PRIVATE_KEY }}'
 
       - id: 'auth'
-        uses: 'google-github-actions/auth@v2'
+        uses: 'google-github-actions/auth@140bb5113ffb6b65a7e9b937a81fa96cf5064462' # ratchet:google-github-actions/auth@v2
         with:
           workload_identity_provider: '${{ vars.GCP_WIF_PROVIDER }}'
           service_account: '${{ vars.SERVICE_ACCOUNT_EMAIL }}'
 
       - name: 'Set up Cloud SDK'
-        uses: 'google-github-actions/setup-gcloud@v2'
+        uses: 'google-github-actions/setup-gcloud@6189d56e4096ee891640bb02ac264be376592d6a' # ratchet:google-github-actions/setup-gcloud@v2
 
       - name: 'Configure Docker for Artifact Registry'
-        run: gcloud auth configure-docker northamerica-northeast1-docker.pkg.dev
+        run: |-
+          gcloud auth configure-docker northamerica-northeast1-docker.pkg.dev
 
       - name: 'Download AlloyDB Auth Proxy'
         run: |
@@ -157,7 +159,8 @@ jobs:
           chmod +x alloydb-auth-proxy
 
       - name: 'Start AlloyDB Auth Proxy'
-        run: ./alloydb-auth-proxy "${{ vars.ALLOYDB_INSTANCE_CONNECTION_NAME }}" --public-ip -i --impersonate-service-account ${{ vars.SERVICE_ACCOUNT_EMAIL }} &
+        run: |-
+          ./alloydb-auth-proxy "${{ vars.ALLOYDB_INSTANCE_CONNECTION_NAME }}" --public-ip -i --impersonate-service-account ${{ vars.SERVICE_ACCOUNT_EMAIL }} &
 
       - name: 'Test AlloyDB Auth Proxy'
         env:

--- a/workflows/issue-triage/gemini-issue-scheduled-triage.yml
+++ b/workflows/issue-triage/gemini-issue-scheduled-triage.yml
@@ -30,8 +30,7 @@ jobs:
 
       - name: 'Generate GitHub App Token'
         id: 'generate_token'
-        if: |-
-          ${{ vars.APP_ID }}
+        if: vars.APP_ID != ''
         uses: 'actions/create-github-app-token@v1'
         with:
           app-id: '${{ vars.APP_ID }}'
@@ -123,8 +122,7 @@ jobs:
             - Reference all shell variables as "${VAR}" (with quotes and braces)
 
   refresh-embeddings:
-    if: |-
-      ${{ vars.ALLOYDB_INSTANCE_CONNECTION_NAME }}
+    if: vars.ALLOYDB_INSTANCE_CONNECTION_NAME != ''
     timeout-minutes: 20
     runs-on: 'ubuntu-latest'
     steps:
@@ -133,8 +131,7 @@ jobs:
 
       - name: 'Generate GitHub App Token'
         id: 'generate_token'
-        if: |-
-          ${{ vars.APP_ID }}
+        if: vars.APP_ID != ''
         uses: 'actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e' # ratchet:actions/create-github-app-token@v2
         with:
           app-id: '${{ vars.APP_ID }}'

--- a/workflows/issue-triage/gemini-issue-scheduled-triage.yml
+++ b/workflows/issue-triage/gemini-issue-scheduled-triage.yml
@@ -30,7 +30,8 @@ jobs:
 
       - name: 'Generate GitHub App Token'
         id: 'generate_token'
-        if: vars.APP_ID != ''
+        if: |-
+          ${{ vars.APP_ID != '' }}
         uses: 'actions/create-github-app-token@v1'
         with:
           app-id: '${{ vars.APP_ID }}'
@@ -122,7 +123,8 @@ jobs:
             - Reference all shell variables as "${VAR}" (with quotes and braces)
 
   refresh-embeddings:
-    if: vars.ALLOYDB_INSTANCE_CONNECTION_NAME != ''
+    if: |-
+      ${{ vars.ALLOYDB_INSTANCE_CONNECTION_NAME != '' }}
     timeout-minutes: 20
     runs-on: 'ubuntu-latest'
     steps:
@@ -131,7 +133,8 @@ jobs:
 
       - name: 'Generate GitHub App Token'
         id: 'generate_token'
-        if: vars.APP_ID != ''
+        if: |-
+          ${{ vars.APP_ID != '' }}
         uses: 'actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e' # ratchet:actions/create-github-app-token@v2
         with:
           app-id: '${{ vars.APP_ID }}'

--- a/workflows/issue-triage/gemini-issue-scheduled-triage.yml
+++ b/workflows/issue-triage/gemini-issue-scheduled-triage.yml
@@ -123,6 +123,7 @@ jobs:
             - Reference all shell variables as "${VAR}" (with quotes and braces)
 
   refresh-embeddings:
+    if: vars.ALLOYDB_INSTANCE_CONNECTION_NAME
     timeout-minutes: 20
     runs-on: 'ubuntu-latest'
     steps:

--- a/workflows/issue-triage/gemini-issue-scheduled-triage.yml
+++ b/workflows/issue-triage/gemini-issue-scheduled-triage.yml
@@ -137,18 +137,20 @@ jobs:
           app-id: '${{ vars.APP_ID }}'
           private-key: '${{ secrets.APP_PRIVATE_KEY }}'
 
-      - id: 'auth'
+      - name: 'Authenticate to Google Cloud'
+        id: 'auth'
         uses: 'google-github-actions/auth@140bb5113ffb6b65a7e9b937a81fa96cf5064462' # ratchet:google-github-actions/auth@v2
         with:
+          token_format: 'access_token'
           workload_identity_provider: '${{ vars.GCP_WIF_PROVIDER }}'
           service_account: '${{ vars.SERVICE_ACCOUNT_EMAIL }}'
 
-      - name: 'Set up Cloud SDK'
-        uses: 'google-github-actions/setup-gcloud@6189d56e4096ee891640bb02ac264be376592d6a' # ratchet:google-github-actions/setup-gcloud@v2
-
-      - name: 'Configure Docker for Artifact Registry'
-        run: |-
-          gcloud auth configure-docker northamerica-northeast1-docker.pkg.dev
+      - name: 'Login to GAR'
+        uses: 'docker/login-action@v3'
+        with:
+          registry: 'northamerica-northeast1-docker.pkg.dev'
+          username: 'oauth2accesstoken'
+          password: '${{ steps.auth.outputs.access_token }}'
 
       - name: 'Download AlloyDB Auth Proxy'
         run: |

--- a/workflows/issue-triage/gemini-issue-scheduled-triage.yml
+++ b/workflows/issue-triage/gemini-issue-scheduled-triage.yml
@@ -78,6 +78,8 @@ jobs:
           GOOGLE_CLOUD_PROJECT: '${{ vars.GOOGLE_CLOUD_PROJECT }}'
           GOOGLE_CLOUD_LOCATION: '${{ vars.GOOGLE_CLOUD_LOCATION }}'
           GOOGLE_GENAI_USE_VERTEXAI: '${{ vars.GOOGLE_GENAI_USE_VERTEXAI }}'
+          GOOGLE_GENAI_USE_GCA: '${{ vars.GOOGLE_GENAI_USE_GCA }}'
+          SERVICE_ACCOUNT_EMAIL: '${{ vars.SERVICE_ACCOUNT_EMAIL }}'
         with:
           settings: |-
             {
@@ -119,3 +121,117 @@ jobs:
             - Do not add comments
             - Triage each issue independently
             - Reference all shell variables as "${VAR}" (with quotes and braces)
+
+  refresh-embeddings:
+    timeout-minutes: 20
+    runs-on: 'ubuntu-latest'
+    steps:
+      - name: 'Checkout repository'
+        uses: 'actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683' # ratchet:actions/checkout@v4
+
+      - name: 'Generate GitHub App Token'
+        id: 'generate_token'
+        if: |-
+          ${{ vars.APP_ID }}
+        uses: 'actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e' # ratchet:actions/create-github-app-token@v2
+        with:
+          app-id: '${{ vars.APP_ID }}'
+          private-key: '${{ secrets.APP_PRIVATE_KEY }}'
+
+      - id: 'auth'
+        uses: 'google-github-actions/auth@v2'
+        with:
+          workload_identity_provider: '${{ vars.GCP_WIF_PROVIDER }}'
+          service_account: '${{ vars.SERVICE_ACCOUNT_EMAIL }}'
+
+      - name: 'Set up Cloud SDK'
+        uses: 'google-github-actions/setup-gcloud@v2'
+
+      - name: 'Configure Docker for Artifact Registry'
+        run: gcloud auth configure-docker northamerica-northeast1-docker.pkg.dev
+
+      - name: 'Download AlloyDB Auth Proxy'
+        run: |
+          curl -o alloydb-auth-proxy https://storage.googleapis.com/alloydb-auth-proxy/v1.13.4/alloydb-auth-proxy.linux.amd64
+          chmod +x alloydb-auth-proxy
+
+      - name: 'Start AlloyDB Auth Proxy'
+        run: ./alloydb-auth-proxy "${{ vars.ALLOYDB_INSTANCE_CONNECTION_NAME }}" --public-ip -i --impersonate-service-account ${{ vars.SERVICE_ACCOUNT_EMAIL }} &
+
+      - name: 'Run Gemini Issue Deduplication Refresh'
+        uses: 'google-github-actions/run-gemini-cli@main'
+        env:
+          GITHUB_TOKEN: '${{ steps.generate_token.outputs.token || secrets.GITHUB_TOKEN }}'
+          REPOSITORY: '${{ github.repository }}'
+          GEMINI_CLI_VERSION: '${{ vars.GEMINI_CLI_VERSION }}'
+          OTLP_GOOGLE_CLOUD_PROJECT: '${{ vars.OTLP_GOOGLE_CLOUD_PROJECT }}'
+          GCP_WIF_PROVIDER: '${{ vars.GCP_WIF_PROVIDER }}'
+          GEMINI_API_KEY: '${{ secrets.GEMINI_API_KEY }}'
+          GOOGLE_CLOUD_PROJECT: '${{ vars.GOOGLE_CLOUD_PROJECT }}'
+          GOOGLE_CLOUD_LOCATION: '${{ vars.GOOGLE_CLOUD_LOCATION }}'
+          GOOGLE_GENAI_USE_VERTEXAI: '${{ vars.GOOGLE_GENAI_USE_VERTEXAI }}'
+          DB_PASS: '${{ secrets.ALLOYDB_DB_PASS }}'
+          INSTANCE_HOST: '127.0.0.1'
+          INSTANCE_PORT: '5432'
+        with:
+          settings: |-
+            {
+              "mcpServers": {
+                "issue_deduplication": {
+                  "command": "docker",
+                  "args": [
+                    "run",
+                    "-i",
+                    "--rm",
+                    "--network=host",
+                    "-e",
+                    "GITHUB_TOKEN",
+                    "-e",
+                    "GEMINI_API_KEY",
+                    "-e",
+                    "DB_USER",
+                    "-e",
+                    "DB_PASS",
+                    "-e",
+                    "INSTANCE_HOST",
+                    "-e",
+                    "INSTANCE_PORT",
+                    "northamerica-northeast1-docker.pkg.dev/quacktastic-waffle/run-gemini-cli/issues-dedup-mcp-server:latest"
+                  ],
+                  "env": {
+                    "GITHUB_TOKEN": "${GITHUB_TOKEN}",
+                    "GEMINI_API_KEY": "${GEMINI_API_KEY}",
+                    "DB_USER": "${DB_USER}",
+                    "DB_PASS": "${DB_PASS}",
+                    "INSTANCE_HOST": "${INSTANCE_HOST}",
+                    "INSTANCE_PORT": "${INSTANCE_PORT}"
+                  },
+                  "enabled": true
+                }
+              },
+              "telemetry": {
+                "enabled": true,
+                "target": "gcp"
+              },
+              "sandbox": false
+            }
+          prompt: |-
+            ## Role
+
+            You are a database maintenance assistant for a GitHub issue deduplication system.
+
+            ## Goal
+
+            Your sole responsibility is to refresh the embeddings for all open issues in the repository to ensure the deduplication database is up-to-date.
+
+            ## Steps
+
+            1.  **Extract Repository Information:** The full repository name is available in the `${REPOSITORY}` environment variable (e.g., "owner/repo"). You will need to parse this to get the `repo_owner` and `repo_name`.
+            2.  **Refresh Embeddings:** Call the `refresh` tool with the correct `repo_owner` and `repo_name`. Do not use the `force` parameter.
+            3.  **Log Output:** Print the JSON output from the `refresh` tool to the logs.
+
+            ## Guidelines
+
+            - Only use the `refresh` tool.
+            - Do not attempt to find duplicates or modify any issues.
+            - Your only task is to call the `refresh` tool and log its output.

--- a/workflows/issue-triage/gemini-issue-scheduled-triage.yml
+++ b/workflows/issue-triage/gemini-issue-scheduled-triage.yml
@@ -95,7 +95,7 @@ jobs:
               },
               "sandbox": false
             }
-          prompt: |
+          prompt: |-
             ## Role
 
             You are an issue triage assistant. Analyze issues and apply
@@ -158,11 +158,20 @@ jobs:
       - name: 'Start AlloyDB Auth Proxy'
         run: ./alloydb-auth-proxy "${{ vars.ALLOYDB_INSTANCE_CONNECTION_NAME }}" --public-ip -i --impersonate-service-account ${{ vars.SERVICE_ACCOUNT_EMAIL }} &
 
+      - name: 'Test AlloyDB Auth Proxy'
+        env:
+          DB_USER: 'postgres'
+          DB_PASS: '${{ secrets.ALLOYDB_DB_PASS }}'
+        run: |
+          PGPASSWORD=$DB_PASS psql "host=127.0.0.1 port=5432 user=$DB_USER dbname=postgres  sslmode=disable" --command="SELECT 1;"
+
       - name: 'Run Gemini Issue Deduplication Refresh'
         uses: 'google-github-actions/run-gemini-cli@main'
         env:
           GITHUB_TOKEN: '${{ steps.generate_token.outputs.token || secrets.GITHUB_TOKEN }}'
           REPOSITORY: '${{ github.repository }}'
+          REPO_OWNER: '${{ github.repository_owner }}'
+          REPO_NAME: '${{ github.event.repository.name }}'
           GEMINI_CLI_VERSION: '${{ vars.GEMINI_CLI_VERSION }}'
           OTLP_GOOGLE_CLOUD_PROJECT: '${{ vars.OTLP_GOOGLE_CLOUD_PROJECT }}'
           GCP_WIF_PROVIDER: '${{ vars.GCP_WIF_PROVIDER }}'
@@ -170,12 +179,17 @@ jobs:
           GOOGLE_CLOUD_PROJECT: '${{ vars.GOOGLE_CLOUD_PROJECT }}'
           GOOGLE_CLOUD_LOCATION: '${{ vars.GOOGLE_CLOUD_LOCATION }}'
           GOOGLE_GENAI_USE_VERTEXAI: '${{ vars.GOOGLE_GENAI_USE_VERTEXAI }}'
+          SERVICE_ACCOUNT_EMAIL: '${{ vars.SERVICE_ACCOUNT_EMAIL }}'
+          DB_USER: 'postgres'
           DB_PASS: '${{ secrets.ALLOYDB_DB_PASS }}'
           INSTANCE_HOST: '127.0.0.1'
           INSTANCE_PORT: '5432'
         with:
           settings: |-
             {
+             "coreTools": [
+                "run_shell_command(echo)"
+              ],
               "mcpServers": {
                 "issue_deduplication": {
                   "command": "docker",
@@ -201,7 +215,7 @@ jobs:
                   "env": {
                     "GITHUB_TOKEN": "${GITHUB_TOKEN}",
                     "GEMINI_API_KEY": "${GEMINI_API_KEY}",
-                    "DB_USER": "${DB_USER}",
+                    "DB_USER": "postgres",
                     "DB_PASS": "${DB_PASS}",
                     "INSTANCE_HOST": "${INSTANCE_HOST}",
                     "INSTANCE_PORT": "${INSTANCE_PORT}"
@@ -226,7 +240,7 @@ jobs:
 
             ## Steps
 
-            1.  **Extract Repository Information:** The full repository name is available in the `${REPOSITORY}` environment variable (e.g., "owner/repo"). You will need to parse this to get the `repo_owner` and `repo_name`.
+            1.  **Extract Repository Information:** The repo_owner/repo_name is ${{ github.repository }}.
             2.  **Refresh Embeddings:** Call the `refresh` tool with the correct `repo_owner` and `repo_name`. Do not use the `force` parameter.
             3.  **Log Output:** Print the JSON output from the `refresh` tool to the logs.
 

--- a/workflows/issue-triage/gemini-issue-scheduled-triage.yml
+++ b/workflows/issue-triage/gemini-issue-scheduled-triage.yml
@@ -171,8 +171,6 @@ jobs:
         env:
           GITHUB_TOKEN: '${{ steps.generate_token.outputs.token || secrets.GITHUB_TOKEN }}'
           REPOSITORY: '${{ github.repository }}'
-          REPO_OWNER: '${{ github.repository_owner }}'
-          REPO_NAME: '${{ github.event.repository.name }}'
           GEMINI_CLI_VERSION: '${{ vars.GEMINI_CLI_VERSION }}'
           OTLP_GOOGLE_CLOUD_PROJECT: '${{ vars.OTLP_GOOGLE_CLOUD_PROJECT }}'
           GCP_WIF_PROVIDER: '${{ vars.GCP_WIF_PROVIDER }}'
@@ -241,8 +239,8 @@ jobs:
 
             ## Steps
 
-            1.  **Extract Repository Information:** The repo_owner/repo_name is ${{ github.repository }}.
-            2.  **Refresh Embeddings:** Call the `refresh` tool with the correct `repo_owner` and `repo_name`. Do not use the `force` parameter.
+            1.  **Extract Repository Information:** The repository is ${{ github.repository }}.
+            2.  **Refresh Embeddings:** Call the `refresh` tool with the correct `repo`. Do not use the `force` parameter.
             3.  **Log Output:** Print the JSON output from the `refresh` tool to the logs.
 
             ## Guidelines


### PR DESCRIPTION
This pull request introduces an automated issue deduplication system workflow. This system uses an MCP server to generate and compare semantic embeddings of GitHub issues, allowing it to identify and report potential duplicates.

 ### Core Feature: Issue Deduplication

   * MCP Server (`scripts/issue-deduplication`):
       * A new FastMCP server is introduced, which connects to an AlloyDB database to store and query issue embeddings.
       * Provides two main tools:
           * refresh: Updates the embeddings for all open issues in a repository.
           * duplicates: Finds issues that are semantically similar to a given issue.
       * Includes a Dockerfile for easy containerization and a setup_alloydb.sh script to automate the provisioning of the required Google Cloud resources.

   * GitHub Actions Workflows:
       * Real-time Duplicate Detection: The gemini-issue-automated-triage.yml workflow now includes a deduplicate-issues job. This job is triggered when a new issue is opened or when a user comments `@gemini-cli /deduplicate`. It calls the MCP server to find duplicates and posts a comment on the issue with the results, and add the `duplicate` label.
       * Scheduled Embedding Refresh: The gemini-issue-scheduled-triage.yml workflow now includes a refresh-embeddings job that runs on a schedule to keep the AlloyDB database up-to-date with the latest issue embeddings.

 ### Future work

   * Update the triggered workflow to allow the bot to automatically close an issue as duplicate (for high enough confidence).
   * Update the scheduled workflow to perform automatic deduplication across all open issues.
