### PR TITLE
docs(readme): clarify inputs and add links

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,10 +55,10 @@ environment variables, and secrets.
 
 <!-- BEGIN_AUTOGEN_INPUTS -->
 
--   <a name="prompt"></a><a href="#user-content-prompt"><code>prompt</code></a>: _(Optional, default: `You are a helpful assistant.`)_ A specific prompt to guide Gemini.
+-   <a name="prompt"></a><a href="#user-content-prompt"><code>prompt</code></a>: _(Optional, default: `You are a helpful assistant.`)_ A string passed to the Gemini CLI's [`--prompt` argument](https://github.com/google-gemini/gemini-cli/blob/main/docs/cli/configuration.md#command-line-arguments).
 
--   <a name="settings"></a><a href="#user-content-settings"><code>settings</code></a>: _(Optional)_ A JSON string to configure the Gemini CLI. This will be written to
-    .gemini/settings.json.
+-   <a name="settings"></a><a href="#user-content-settings"><code>settings</code></a>: _(Optional)_ A JSON string written to `.gemini/settings.json` to configure the CLI's _project_ settings.
+    For more details, see the documentation on [settings files](https://github.com/google-gemini/gemini-cli/blob/main/docs/cli/configuration.md#settings-files).
 
 
 <!-- END_AUTOGEN_INPUTS -->

--- a/action.yml
+++ b/action.yml
@@ -19,13 +19,14 @@ description: |-
 
 inputs:
   prompt:
-    description: 'A specific prompt to guide Gemini.'
+    description: |
+      A string passed to the Gemini CLI's [`--prompt` argument](https://github.com/google-gemini/gemini-cli/blob/main/docs/cli/configuration.md#command-line-arguments).
     required: false
     default: 'You are a helpful assistant.'
   settings:
     description: |
-      A JSON string to configure the Gemini CLI. This will be written to
-      .gemini/settings.json.
+      A JSON string written to `.gemini/settings.json` to configure the CLI's _project_ settings.
+      For more details, see the documentation on [settings files](https://github.com/google-gemini/gemini-cli/blob/main/docs/cli/configuration.md#settings-files).
     required: false
 
 outputs:


### PR DESCRIPTION
Clarify how the inputs are passed to the Gemini CLI and add links to docs that Gemini CLI uses to define these terms.

Updates were made to the `actions.yml` file, and then the readme was updated by running `npm run docs`