### PR TITLE
feat: Support GitHub MCP

### DIFF
--- a/.github/workflows/gemini-pr-review.yml
+++ b/.github/workflows/gemini-pr-review.yml
@@ -164,11 +164,29 @@ jobs:
           settings: |-
             {
               "maxSessionTurns": 20,
+              "mcpServers": {
+                "github": {
+                  "command": "docker",
+                  "args": [
+                    "run",
+                    "-i",
+                    "--rm",
+                    "-e",
+                    "GITHUB_PERSONAL_ACCESS_TOKEN",
+                    "ghcr.io/github/github-mcp-server"
+                  ],
+                  "env": {
+                    "GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_TOKEN}"
+                  }
+                }
+              },
               "coreTools": [
+                "mcp__github__create_pending_pull_request_review",
+                "mcp__github__add_comment_to_pending_review",
+                "mcp__github__submit_pending_pull_request_review",
                 "run_shell_command(echo)",
                 "run_shell_command(gh pr view)",
                 "run_shell_command(gh pr diff)",
-                "run_shell_command(gh pr comment)",
                 "run_shell_command(cat)",
                 "run_shell_command(head)",
                 "run_shell_command(tail)",
@@ -218,8 +236,10 @@ jobs:
             Once you have the information, provide a comprehensive code review by:
             1. Writing your review to a file: write_file("review.md", "<your
                detailed review feedback here>")
-            2. Posting the review: gh pr comment "${PR_NUMBER}" --body-file
-               review.md --repo "${REPOSITORY}"
+            2. Posting the review:
+                2.1 Use the mcp__github__create_pending_pull_request_review to create a Pending Pull Request Review.
+                2.2 Use the mcp__github__add_comment_to_pending_review to add comments to the Pending Pull Request Review. Inline comments are preffered whenever possible, so repeat this step, calling mcp__github__add_comment_to_pending_review, as needed. All comments about specific lines of code should use inline comments.
+                2.3 Use the mcp__github__submit_pending_pull_request_review to submit the Pending Pull Request Review.
 
             Review Areas:
             - **Security**: Authentication, authorization, input validation,

--- a/workflows/pr-review/gemini-pr-review.yml
+++ b/workflows/pr-review/gemini-pr-review.yml
@@ -109,6 +109,7 @@ jobs:
             echo "EOF"
           } >> "${GITHUB_OUTPUT}"
 
+
       - name: 'Get PR details (issue_comment)'
         id: 'get_pr_comment'
         if: |-
@@ -163,11 +164,29 @@ jobs:
           settings: |-
             {
               "maxSessionTurns": 20,
+              "mcpServers": {
+                "github": {
+                  "command": "docker",
+                  "args": [
+                    "run",
+                    "-i",
+                    "--rm",
+                    "-e",
+                    "GITHUB_PERSONAL_ACCESS_TOKEN",
+                    "ghcr.io/github/github-mcp-server"
+                  ],
+                  "env": {
+                    "GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_TOKEN}"
+                  }
+                }
+              },
               "coreTools": [
+                "mcp__github__create_pending_pull_request_review",
+                "mcp__github__add_comment_to_pending_review",
+                "mcp__github__submit_pending_pull_request_review",
                 "run_shell_command(echo)",
                 "run_shell_command(gh pr view)",
                 "run_shell_command(gh pr diff)",
-                "run_shell_command(gh pr comment)",
                 "run_shell_command(cat)",
                 "run_shell_command(head)",
                 "run_shell_command(tail)",
@@ -217,8 +236,10 @@ jobs:
             Once you have the information, provide a comprehensive code review by:
             1. Writing your review to a file: write_file("review.md", "<your
                detailed review feedback here>")
-            2. Posting the review: gh pr comment "${PR_NUMBER}" --body-file
-               review.md --repo "${REPOSITORY}"
+            2. Posting the review:
+                2.1 Use the mcp__github__create_pending_pull_request_review to create a Pending Pull Request Review.
+                2.2 Use the mcp__github__add_comment_to_pending_review to add comments to the Pending Pull Request Review. Inline comments are preffered whenever possible, so repeat this step, calling mcp__github__add_comment_to_pending_review, as needed. All comments about specific lines of code should use inline comments.
+                2.3 Use the mcp__github__submit_pending_pull_request_review to submit the Pending Pull Request Review.
 
             Review Areas:
             - **Security**: Authentication, authorization, input validation,


### PR DESCRIPTION
### Description
Implements #54 to support GitHub MCP for the `gemini-pr-review.yml` workflow. This enables a natural language interface for the Gemini-CLI to interact with GitHub. This follows the broader approach in the [Gemini CLI tutorial](https://github.com/google-gemini/gemini-cli/blob/7bc876654254d9a11d66135735ad10f1066ad213/docs/cli/tutorials.md#guide), and the [GitHub MCP Server readme](https://github.com/github/github-mcp-server)

### Key Changes
- Updated an `mcpServers` section to the settings to add the official GitHub MCP server, passing in the `GITHUB_TOKEN` for authentication
- Updated the `coreTools` settings to add the new MCP commands, and remove the conflicting `gh` CLI commands
- Updated the prompt on how to invoke the MCP commands

### Testing
Created an example PR in a forked repository with some intentional mistakes and ran the new workload, which created this PR Review: <img width="830" height="991" alt="image" src="https://github.com/user-attachments/assets/b4b5ffbd-4429-42ab-ba05-5d522f450f67" />