### PR TITLE
fix(workflows): simplify manual trigger for scheduled triage

### DIFF
--- a/.github/workflows/gemini-issue-scheduled-triage.yml
+++ b/.github/workflows/gemini-issue-scheduled-triage.yml
@@ -4,11 +4,6 @@ on:
   schedule:
     - cron: '0 * * * *' # Runs every hour
   workflow_dispatch:
-    inputs:
-      issue_number:
-        description: 'issue number to triage'
-        required: true
-        type: 'number'
 
 concurrency:
   group: '${{ github.workflow }}'
@@ -127,17 +122,3 @@ jobs:
             - Do not add comments
             - Triage each issue independently
             - Reference all shell variables as "${VAR}" (with quotes and braces)
-
-      - name: 'Post Issue Triage Failure Comment'
-        if: |-
-          ${{ failure() && steps.gemini_issue_triage.outcome == 'failure' }}
-        uses: 'actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea'
-        with:
-          github-token: '${{ steps.generate_token.outputs.token || secrets.GITHUB_TOKEN }}'
-          script: |
-            github.rest.issues.createComment({
-              owner: '${{ github.repository }}'.split('/')[0],
-              repo: '${{ github.repository }}'.split('/')[1],
-              issue_number: '${{ github.event.issue.number || github.event.inputs.issue_number }}',
-              body: 'There is a problem with the Gemini CLI issue triaging. Please check the [action logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for details.'
-            })

--- a/workflows/issue-triage/gemini-issue-scheduled-triage.yml
+++ b/workflows/issue-triage/gemini-issue-scheduled-triage.yml
@@ -26,13 +26,13 @@ jobs:
 
     steps:
       - name: 'Checkout repository'
-        uses: 'actions/checkout@v4'
+        uses: 'actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683' # ratchet:actions/checkout@v4
 
       - name: 'Generate GitHub App Token'
         id: 'generate_token'
         if: |-
           ${{ vars.APP_ID }}
-        uses: 'actions/create-github-app-token@v1'
+        uses: 'actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e' # ratchet:actions/create-github-app-token@v2
         with:
           app-id: '${{ vars.APP_ID }}'
           private-key: '${{ secrets.APP_PRIVATE_KEY }}'
@@ -67,6 +67,7 @@ jobs:
         if: |-
           ${{ steps.find_issues.outputs.issues_to_triage != '[]' }}
         uses: 'google-github-actions/run-gemini-cli@main'
+        id: 'gemini_issue_triage'
         env:
           GITHUB_TOKEN: '${{ steps.generate_token.outputs.token }}'
           ISSUES_TO_TRIAGE: '${{ steps.find_issues.outputs.issues_to_triage }}'
@@ -95,7 +96,7 @@ jobs:
               },
               "sandbox": false
             }
-          prompt: |
+          prompt: |-
             ## Role
 
             You are an issue triage assistant. Analyze issues and apply


### PR DESCRIPTION
This commit updates the scheduled issue triage workflow to simplify manual runs and align it with the source workflow.

The `issue_number` input for the `workflow_dispatch` trigger has been removed. The workflow now automatically identifies all untriaged issues, so a manual issue selection is no longer needed. This allows for manually triggering a triage run for all relevant issues at once.

Additionally, the step that posts a failure comment was removed to avoid spamming issues if the scheduled triage fails.
