### PR TITLE
feat: sync issue triage workflow with dogfooding

### DIFF
--- a/workflows/issue-triage/README.md
+++ b/workflows/issue-triage/README.md
@@ -73,6 +73,8 @@ Alternatively, you can manually copy the contents of the workflow files from thi
 
 This workflow is defined in `workflows/issue-triage/gemini-issue-automated-triage.yml` and is triggered when an issue is opened or reopened. It uses the Gemini CLI to analyze the issue and apply relevant labels.
 
+If the triage process encounters an error, the workflow will post a comment on the issue, including a link to the action logs for debugging.
+
 ### Scheduled Issue Triage
 
 This workflow is defined in `workflows/issue-triage/gemini-issue-scheduled-triage.yml` and runs on a schedule (e.g., every hour). It finds any issues that have no labels or have the `status/needs-triage` label and then uses the Gemini CLI to triage them. This workflow can also be manually triggered.

--- a/workflows/issue-triage/gemini-issue-automated-triage.yml
+++ b/workflows/issue-triage/gemini-issue-automated-triage.yml
@@ -44,19 +44,20 @@ jobs:
 
     steps:
       - name: 'Checkout repository'
-        uses: 'actions/checkout@v4'
+        uses: 'actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683' # ratchet:actions/checkout@v4
 
       - name: 'Generate GitHub App Token'
         id: 'generate_token'
         if: |-
           ${{ vars.APP_ID }}
-        uses: 'actions/create-github-app-token@v1'
+        uses: 'actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e' # ratchet:actions/create-github-app-token@v2
         with:
           app-id: '${{ vars.APP_ID }}'
           private-key: '${{ secrets.APP_PRIVATE_KEY }}'
 
       - name: 'Run Gemini Issue Triage'
         uses: 'google-github-actions/run-gemini-cli@main'
+        id: 'gemini_issue_triage'
         env:
           GITHUB_TOKEN: '${{ steps.generate_token.outputs.token || secrets.GITHUB_TOKEN }}'
           ISSUE_TITLE: '${{ github.event.issue.title }}'
@@ -113,3 +114,17 @@ jobs:
             - Triage only the current issue
             - Assign all applicable labels based on the issue content
             - Reference all shell variables as "${VAR}" (with quotes and braces)
+
+      - name: 'Post Issue Triage Failure Comment'
+        if: |-
+          ${{ failure() && steps.gemini_issue_triage.outcome == 'failure' }}
+        uses: 'actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea'
+        with:
+          github-token: '${{ steps.generate_token.outputs.token || secrets.GITHUB_TOKEN }}'
+          script: |
+            github.rest.issues.createComment({
+              owner: '${{ github.repository }}'.split('/')[0],
+              repo: '${{ github.repository }}'.split('/')[1],
+              issue_number: '${{ github.event.issue.number }}',
+              body: 'There is a problem with the Gemini CLI issue triaging. Please check the [action logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for details.'
+            })


### PR DESCRIPTION
This commit synchronizes the issue triage workflow with the version used in dogfooding.

The main changes are:
- Pinning the actions to a specific commit hash to ensure stability.
- Adding a step to post a comment on the issue if the triage fails.

<!--
Thank you for proposing a pull request! Please note that SOME TESTS WILL
LIKELY FAIL due to how GitHub exposes secrets in Pull Requests from forks.
Someone from the team will review your Pull Request and respond.

Please describe your change and any implementation details below.
-->
