### PR TITLE
feat: add failure notification to pr review workflow

### DIFF
--- a/workflows/pr-review/README.md
+++ b/workflows/pr-review/README.md
@@ -41,6 +41,7 @@ The PR Review workflow uses Google's Gemini AI to provide comprehensive code rev
 - **Positive Highlights**: Acknowledges good practices and well-written code
 - **Custom Instructions**: Support for specific review focus areas
 - **Structured Output**: Consistent markdown format for easy reading
+- **Failure Notifications**: Posts a comment on the PR if the review process fails.
 
 ## Setup
 

--- a/workflows/pr-review/gemini-pr-review.yml
+++ b/workflows/pr-review/gemini-pr-review.yml
@@ -66,15 +66,13 @@ jobs:
 
     steps:
       - name: 'Checkout PR code'
-        uses: 'actions/checkout@v4'
-        with:
-          fetch-depth: 0
+        uses: 'actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683' # ratchet:actions/checkout@v4
 
       - name: 'Generate GitHub App Token'
         id: 'generate_token'
         if: |-
           ${{ vars.APP_ID }}
-        uses: 'actions/create-github-app-token@v1'
+        uses: 'actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e' # ratchet:actions/create-github-app-token@v2
         with:
           app-id: '${{ vars.APP_ID }}'
           private-key: '${{ secrets.APP_PRIVATE_KEY }}'
@@ -144,6 +142,7 @@ jobs:
 
       - name: 'Run Gemini PR Review'
         uses: 'google-github-actions/run-gemini-cli@main'
+        id: 'gemini_pr_review'
         env:
           GITHUB_TOKEN: '${{ steps.generate_token.outputs.token || secrets.GITHUB_TOKEN }}'
           PR_NUMBER: '${{ steps.get_pr.outputs.pr_number || steps.get_pr_comment.outputs.pr_number }}'
@@ -302,3 +301,17 @@ jobs:
             - List any questions you have about the implementation
             - Clarifications needed from the author
             '''
+
+      - name: 'Post PR review failure comment'
+        if: |-
+          ${{ failure() && steps.gemini_pr_review.outcome == 'failure' }}
+        uses: 'actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea'
+        with:
+          github-token: '${{ steps.generate_token.outputs.token || secrets.GITHUB_TOKEN }}'
+          script: |
+            github.rest.issues.createComment({
+              owner: '${{ github.repository }}'.split('/')[0],
+              repo: '${{ github.repository }}'.split('/')[1],
+              issue_number: '${{ steps.get_pr.outputs.pr_number || steps.get_pr_comment.outputs.pr_number }}',
+              body: 'There is a problem with the Gemini CLI PR review. Please check the [action logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for details.'
+            })


### PR DESCRIPTION
This adds a new step to the PR review workflow that posts a comment to the PR if the Gemini CLI review fails. This provides better visibility into workflow failures.