### PR TITLE
feat: update workflow timeouts and document changes

### DIFF
--- a/.github/workflows/gemini-cli.yml
+++ b/.github/workflows/gemini-cli.yml
@@ -83,7 +83,7 @@ jobs:
           )
         )
       )
-    timeout-minutes: 15
+    timeout-minutes: 10
     runs-on: 'ubuntu-latest'
 
     steps:

--- a/.github/workflows/gemini-issue-scheduled-triage.yml
+++ b/.github/workflows/gemini-issue-scheduled-triage.yml
@@ -21,7 +21,7 @@ permissions:
 
 jobs:
   triage-issues:
-    timeout-minutes: 10
+    timeout-minutes: 5
     runs-on: 'ubuntu-latest'
 
     steps:

--- a/.github/workflows/gemini-pr-review.yml
+++ b/.github/workflows/gemini-pr-review.yml
@@ -61,7 +61,7 @@ jobs:
           github.event.review.author_association == 'COLLABORATOR'
         )
       )
-    timeout-minutes: 15
+    timeout-minutes: 5
     runs-on: 'ubuntu-latest'
 
     steps:

--- a/workflows/README.md
+++ b/workflows/README.md
@@ -8,6 +8,22 @@ This directory contains a collection of example workflows that demonstrate how t
 *   **[Pull Request Review](./pr-review)**: Automatically review pull requests using Gemini. This workflow can be triggered by pull request events and provides a comprehensive review of the changes.
 *   **[Gemini CLI](./gemini-cli)**: A general-purpose, conversational AI assistant that can be invoked within pull requests and issues to perform a wide range of tasks.
 
+## Configuration
+
+### Workflows
+
+#### Timeouts
+
+Each workflow includes a `timeout-minutes` property that you can customize to meet your needs. This property determines the maximum amount of time that a job can run before it is automatically canceled. For more information on configuring timeouts, see the official GitHub documentation for [`jobs.<job_id>.timeout-minutes`](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idtimeout-minutes) and [`jobs.<job_id>.steps.timeout-minutes`](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idstepstimeout-minutes).
+
+To change the timeout for a workflow, open the corresponding YAML file and modify the value of the `timeout-minutes` property. For example, to change the timeout for the Pull Request Review workflow to 10 minutes, you would make the following change:
+
+```yaml
+jobs:
+  review-pr:
+    timeout-minutes: 10
+```
+
 ## Contributing
 
 We encourage you to contribute to this collection of workflows! If you have a workflow that you would like to share with the community, please open a pull request.

--- a/workflows/gemini-cli/gemini-cli.yml
+++ b/workflows/gemini-cli/gemini-cli.yml
@@ -83,7 +83,7 @@ jobs:
           )
         )
       )
-    timeout-minutes: 15
+    timeout-minutes: 10
     runs-on: 'ubuntu-latest'
 
     steps:

--- a/workflows/issue-triage/gemini-issue-scheduled-triage.yml
+++ b/workflows/issue-triage/gemini-issue-scheduled-triage.yml
@@ -21,7 +21,7 @@ permissions:
 
 jobs:
   triage-issues:
-    timeout-minutes: 10
+    timeout-minutes: 5
     runs-on: 'ubuntu-latest'
 
     steps:

--- a/workflows/pr-review/gemini-pr-review.yml
+++ b/workflows/pr-review/gemini-pr-review.yml
@@ -61,7 +61,7 @@ jobs:
           github.event.review.author_association == 'COLLABORATOR'
         )
       )
-    timeout-minutes: 15
+    timeout-minutes: 5
     runs-on: 'ubuntu-latest'
 
     steps:


### PR DESCRIPTION
This commit introduces two main changes:

1. The default timeouts for the gemini-cli, gemini-issue-scheduled-triage, and gemini-pr-review workflows have been updated to more reasonable values to prevent excessive resource usage. The gemini-issue-automated-triage had a reasonable timeout already.

2. The workflows/README.md has been updated to include instructions on how users can customize the timeout-minutes for each workflow.

These changes improve the safety and usability of the provided example workflows.

