### PR TITLE
feat(workflows): add maxSessionTurns to all workflows

### DIFF
--- a/.github/workflows/gemini-cli.yml
+++ b/.github/workflows/gemini-cli.yml
@@ -184,6 +184,7 @@ jobs:
         with:
           settings: |
             {
+              "maxSessionTurns": 50,
               "coreTools": [
                 "run_shell_command(echo)",
                 "run_shell_command(gh pr view)",

--- a/.github/workflows/gemini-issue-automated-triage.yml
+++ b/.github/workflows/gemini-issue-automated-triage.yml
@@ -76,6 +76,7 @@ jobs:
         with:
           settings: |-
             {
+              "maxSessionTurns": 25,
               "coreTools": [
                 "run_shell_command(gh label list)",
                 "run_shell_command(gh issue edit)"

--- a/.github/workflows/gemini-issue-scheduled-triage.yml
+++ b/.github/workflows/gemini-issue-scheduled-triage.yml
@@ -84,6 +84,7 @@ jobs:
         with:
           settings: |-
             {
+              "maxSessionTurns": 25,
               "coreTools": [
                 "run_shell_command(echo)",
                 "run_shell_command(gh label list)",

--- a/.github/workflows/gemini-pr-review.yml
+++ b/.github/workflows/gemini-pr-review.yml
@@ -163,6 +163,7 @@ jobs:
         with:
           settings: |-
             {
+              "maxSessionTurns": 20,
               "coreTools": [
                 "run_shell_command(echo)",
                 "run_shell_command(gh pr view)",

--- a/README.md
+++ b/README.md
@@ -75,15 +75,15 @@ environment variables, and secrets.
 
 Set the following environment variables in your repository or workflow:
 
-| Name                      | Description                                                                                 | Type     | Required | When Required                |
-|---------------------------|---------------------------------------------------------------------------------------------|----------|----------|------------------------------|
-| GEMINI_CLI_VERSION        | Controls which version of the Gemini CLI is installed. Supports `npm` versions (e.g., `0.1.0`, `latest`), a branch name (e.g., `main`), or a commit hash. | Variable | No       | To pin or override the CLI version |
-| GCP_WIF_PROVIDER          | Full resource name of the Workload Identity Provider.                                       | Variable | No       | When using observability               |
-| OTLP_GOOGLE_CLOUD_PROJECT | Google Cloud project for telemetry.                                                         | Variable | No       | When using observability               |
-| GOOGLE_CLOUD_PROJECT      | Google Cloud project for Vertex AI authentication.                                          | Variable | No       | When using Vertex AI authentication    |
-| GOOGLE_CLOUD_LOCATION     | Geographic location of the Google Cloud project for Vertex AI authentication.               | Variable | No       | When using Vertex AI authentication    |
-| GOOGLE_GENAI_USE_VERTEXAI | Set to 'true' to use Vertex AI                                                              | Variable | No       | When using Vertex AI authentication    |
-| APP_ID                    | GitHub App ID for custom authentication.                                                    | Variable | No       | When using a custom GitHub App         |
+| Name                      | Description                                                                                                                                               | Type     | Required | When Required                       |
+| ------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | -------- | ----------------------------------- |
+| GEMINI_CLI_VERSION        | Controls which version of the Gemini CLI is installed. Supports `npm` versions (e.g., `0.1.0`, `latest`), a branch name (e.g., `main`), or a commit hash. | Variable | No       | To pin or override the CLI version  |
+| GCP_WIF_PROVIDER          | Full resource name of the Workload Identity Provider.                                                                                                     | Variable | No       | When using observability            |
+| OTLP_GOOGLE_CLOUD_PROJECT | Google Cloud project for telemetry.                                                                                                                       | Variable | No       | When using observability            |
+| GOOGLE_CLOUD_PROJECT      | Google Cloud project for Vertex AI authentication.                                                                                                        | Variable | No       | When using Vertex AI authentication |
+| GOOGLE_CLOUD_LOCATION     | Geographic location of the Google Cloud project for Vertex AI authentication.                                                                             | Variable | No       | When using Vertex AI authentication |
+| GOOGLE_GENAI_USE_VERTEXAI | Set to 'true' to use Vertex AI                                                                                                                            | Variable | No       | When using Vertex AI authentication |
+| APP_ID                    | GitHub App ID for custom authentication.                                                                                                                  | Variable | No       | When using a custom GitHub App      |
 
 
 To add an environment variable: 1) Go to your repository's **Settings > Secrets and
@@ -95,10 +95,10 @@ For organization-wide or environment-specific variables, refer to the
 
 The following secrets are required for security:
 
-| Name              | Description                                   | Required | When Required                                             |
-|-------------------|-----------------------------------------------|----------|-----------------------------------------------------------|
-| GEMINI_API_KEY    | Your Gemini API key from Google AI Studio.    | No       | If you are using the Gemini API key from Google AI Studio |
-| APP_PRIVATE_KEY   | Private key for your GitHub App (PEM format). | No       | If you are using a custom GitHub App                      |
+| Name            | Description                                   | Required | When Required                                             |
+| --------------- | --------------------------------------------- | -------- | --------------------------------------------------------- |
+| GEMINI_API_KEY  | Your Gemini API key from Google AI Studio.    | No       | If you are using the Gemini API key from Google AI Studio |
+| APP_PRIVATE_KEY | Private key for your GitHub App (PEM format). | No       | If you are using a custom GitHub App                      |
 
 To add a secret, go to your repository's **Settings > Secrets and variables >
 Actions > New repository secret**. For more information, refer to the
@@ -136,11 +136,6 @@ This type of action can be used to invoke a general-purpose, conversational Gemi
 AI assistant within the pull requests and issues to perform a wide range of
 tasks. For a detailed guide on how to set up the [Gemini CLI], go to the Generic
 [Gemini CLI workflow documentation](./workflows/gemini-cli).
-
-You can configure the [`maxSessionTurns`](https://github.com/google-gemini/gemini-cli/blob/main/docs/cli/configuration.md#available-settings-in-settingsjson)
-when running the Gemini CLI in the workflow's YAML configuration file if you want to restrict
-the maximum number of session turns for each of the `yolo` Gemini CLI runs. In the 'Run Gemini' step ,
-you can configure the `maxSessionTurns` in the settings.
 
 ## Authentication
 

--- a/workflows/README.md
+++ b/workflows/README.md
@@ -2,6 +2,16 @@
 
 This directory contains a collection of example workflows that demonstrate how to use the [Google Gemini CLI GitHub Action](https://github.com/google-github-actions/run-gemini-cli). These workflows are designed to be reusable and customizable for your own projects.
 
+- [Gemini CLI Workflows](#gemini-cli-workflows)
+  - [Available Workflows](#available-workflows)
+  - [Configuration](#configuration)
+    - [Workflows](#workflows)
+      - [Timeouts](#timeouts)
+    - [Settings](#settings)
+      - [`maxSessionTurns`](#maxsessionturns)
+  - [Contributing](#contributing)
+
+
 ## Available Workflows
 
 *   **[Issue Triage](./issue-triage)**: Automatically triage GitHub issues using Gemini. This workflow can be configured to run on a schedule or be triggered by issue events.
@@ -22,6 +32,36 @@ To change the timeout for a workflow, open the corresponding YAML file and modif
 jobs:
   review-pr:
     timeout-minutes: 10
+```
+
+### Settings
+
+You can customize the behavior of the Gemini CLI by modifying the `settings` input in your workflow files.
+
+For more information on all available settings, please see the [Gemini CLI documentation](https://github.com/google-gemini/gemini-cli/blob/main/docs/cli/configuration.md#available-settings-in-settingsjson).
+
+#### `maxSessionTurns`
+
+This setting controls the maximum number of turns in a conversation.
+
+**Defaults:**
+
+The default `maxSessionTurns` for each workflow is as follows:
+
+| Workflow                           | Default `maxSessionTurns` |
+| ---------------------------------- | ------------------------- |
+| [Issue Triage](./issue-triage)     | 25                        |
+| [Pull Request Review](./pr-review) | 20                        |
+| [Gemini CLI](./gemini-cli)         | 50                        |
+
+**Example:**
+
+```yaml
+with:
+  settings: |
+    {
+      "maxSessionTurns": 10
+    }
 ```
 
 ## Contributing

--- a/workflows/gemini-cli/gemini-cli.yml
+++ b/workflows/gemini-cli/gemini-cli.yml
@@ -184,6 +184,7 @@ jobs:
         with:
           settings: |
             {
+              "maxSessionTurns": 50,
               "coreTools": [
                 "run_shell_command(echo)",
                 "run_shell_command(gh pr view)",

--- a/workflows/issue-triage/gemini-issue-automated-triage.yml
+++ b/workflows/issue-triage/gemini-issue-automated-triage.yml
@@ -76,6 +76,7 @@ jobs:
         with:
           settings: |-
             {
+              "maxSessionTurns": 25,
               "coreTools": [
                 "run_shell_command(gh label list)",
                 "run_shell_command(gh issue edit)"

--- a/workflows/issue-triage/gemini-issue-scheduled-triage.yml
+++ b/workflows/issue-triage/gemini-issue-scheduled-triage.yml
@@ -84,6 +84,7 @@ jobs:
         with:
           settings: |-
             {
+              "maxSessionTurns": 25,
               "coreTools": [
                 "run_shell_command(echo)",
                 "run_shell_command(gh label list)",

--- a/workflows/pr-review/gemini-pr-review.yml
+++ b/workflows/pr-review/gemini-pr-review.yml
@@ -162,6 +162,7 @@ jobs:
         with:
           settings: |-
             {
+              "maxSessionTurns": 20,
               "coreTools": [
                 "run_shell_command(echo)",
                 "run_shell_command(gh pr view)",


### PR DESCRIPTION
This commit introduces the `maxSessionTurns` setting to all Gemini CLI workflows, providing granular control over the conversation length for each use case. This enhancement allows for more tailored and efficient interactions with the Gemini assistant, preventing runaway conversations and ensuring that the AI's focus remains on the specific task at hand.

The following changes are included in this commit:

- **`maxSessionTurns` added to all workflows:** Each of the three primary workflows (issue triage, pull request review, and the general CLI) now has a `maxSessionTurns` value configured in its corresponding workflow file. These values have been set to reasonable defaults for each use case:
    - Issue Triage: 25
    - Pull Request Review: 20
    - General CLI: 50
- **Documentation updated:** The `workflows/README.md` file has been updated to include a new "Configuration" section that explains how to use the `maxSessionTurns` setting. This documentation provides a clear example of how to modify the setting and links to the comprehensive Gemini CLI documentation for more information.

By providing this level of control, we empower users to fine-tune the behavior of the Gemini CLI to better suit their specific needs and preferences, leading to a more efficient and effective AI-assisted workflow.

