### PR TITLE
Support code suggestions in `@gemini-cli /review`

### DIFF
--- a/.github/workflows/gemini-pr-review.yml
+++ b/.github/workflows/gemini-pr-review.yml
@@ -239,7 +239,7 @@ jobs:
             2. Posting the review:
                 2.1 Use the mcp__github__create_pending_pull_request_review to create a Pending Pull Request Review.
                 2.2 Use the mcp__github__add_comment_to_pending_review to add comments to the Pending Pull Request Review. Inline comments are preffered whenever possible, so repeat this step, calling mcp__github__add_comment_to_pending_review, as needed. All comments about specific lines of code should use inline comments. It is preferred to use code suggestions when possible, which include a code block that is labeled "suggestion", which contains what the new code should be. An example is:
-                  {{COMMENT_TEXT}} 
+                  {{COMMENT_TEXT}}
                   ```suggestion
                   {{CODE_SUGGESTION}}
                   ```

--- a/workflows/pr-review/gemini-pr-review.yml
+++ b/workflows/pr-review/gemini-pr-review.yml
@@ -239,7 +239,7 @@ jobs:
             2. Posting the review:
                 2.1 Use the mcp__github__create_pending_pull_request_review to create a Pending Pull Request Review.
                 2.2 Use the mcp__github__add_comment_to_pending_review to add comments to the Pending Pull Request Review. Inline comments are preffered whenever possible, so repeat this step, calling mcp__github__add_comment_to_pending_review, as needed. All comments about specific lines of code should use inline comments. It is preferred to use code suggestions when possible, which include a code block that is labeled "suggestion", which contains what the new code should be. An example is:
-                  {{COMMENT_TEXT}} 
+                  {{COMMENT_TEXT}}
                   ```suggestion
                   {{CODE_SUGGESTION}}
                   ```


### PR DESCRIPTION
### Description
Enable GitHub PR suggestions in inline comments

### Approach
This PR tells the `@gemini-cli /review` agent to prefer GitHub suggestions. 

So instead of the model posting a comment like:
```
You should change this line to: <NEW CODE>
```

It should instead follow the format:
````
You should change this line to 
```suggestion
<NEW CODE>
```
````

### Testing
Ran this action on an example PR and see the suggestions (boxed for convenience):
<img width="629" height="1270" alt="image" src="https://github.com/user-attachments/assets/f67199e6-2c12-4fa8-82f8-b43356f30349" />