### PR TITLE
refactor: remove redundant sandbox flag

### DIFF
--- a/.github/workflows/gemini-cli.yml
+++ b/.github/workflows/gemini-cli.yml
@@ -312,8 +312,7 @@ jobs:
               "telemetry": {
                 "enabled": true,
                 "target": "gcp"
-              },
-              "sandbox": false
+              }
             }
           prompt: |-
             ## Role & Goal

--- a/.github/workflows/gemini-issue-automated-triage.yml
+++ b/.github/workflows/gemini-issue-automated-triage.yml
@@ -83,8 +83,7 @@ jobs:
               "telemetry": {
                 "enabled": true,
                 "target": "gcp"
-              },
-              "sandbox": false
+              }
             }
           prompt: |-
             ## Role

--- a/.github/workflows/gemini-issue-scheduled-triage.yml
+++ b/.github/workflows/gemini-issue-scheduled-triage.yml
@@ -93,8 +93,7 @@ jobs:
               "telemetry": {
                 "enabled": true,
                 "target": "gcp"
-              },
-              "sandbox": false
+              }
             }
           prompt: |-
             ## Role

--- a/.github/workflows/gemini-pr-review.yml
+++ b/.github/workflows/gemini-pr-review.yml
@@ -196,8 +196,7 @@ jobs:
               "telemetry": {
                 "enabled": true,
                 "target": "gcp"
-              },
-              "sandbox": false
+              }
             }
           prompt: |-
             ## Role

--- a/workflows/gemini-cli/gemini-cli.yml
+++ b/workflows/gemini-cli/gemini-cli.yml
@@ -312,8 +312,7 @@ jobs:
               "telemetry": {
                 "enabled": true,
                 "target": "gcp"
-              },
-              "sandbox": false
+              }
             }
           prompt: |-
             ## Role & Goal

--- a/workflows/issue-triage/gemini-issue-automated-triage.yml
+++ b/workflows/issue-triage/gemini-issue-automated-triage.yml
@@ -83,8 +83,7 @@ jobs:
               "telemetry": {
                 "enabled": true,
                 "target": "gcp"
-              },
-              "sandbox": false
+              }
             }
           prompt: |-
             ## Role

--- a/workflows/issue-triage/gemini-issue-scheduled-triage.yml
+++ b/workflows/issue-triage/gemini-issue-scheduled-triage.yml
@@ -93,8 +93,7 @@ jobs:
               "telemetry": {
                 "enabled": true,
                 "target": "gcp"
-              },
-              "sandbox": false
+              }
             }
           prompt: |-
             ## Role

--- a/workflows/pr-review/gemini-pr-review.yml
+++ b/workflows/pr-review/gemini-pr-review.yml
@@ -196,8 +196,7 @@ jobs:
               "telemetry": {
                 "enabled": true,
                 "target": "gcp"
-              },
-              "sandbox": false
+              }
             }
           prompt: |-
             ## Role


### PR DESCRIPTION
The `sandbox` input for the `google-github-actions/run-gemini-cli` action defaults to `false`. This commit removes the explicit `sandbox: false` setting from the workflows, as it is redundant.
