### PR TITLE
feat(docs): clarify OWNER in setup script instructions

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -37,7 +37,7 @@ For detailed setup instructions, see the [Workload Identity Federation documenta
 ./scripts/setup_workload_identity.sh --repo <OWNER/REPO> --project <PROJECT_ID>
 ```
 
--   `<OWNER/REPO>`: Your GitHub repository in the format `owner/repo`.
+-   `<OWNER/REPO>`: Your GitHub repository in the format `owner/repo`. Here, `OWNER` means your GitHub organization (for organization-owned repos) or username (for user-owned repos).
 -   `<PROJECT_ID>`: Your Google Cloud `project_id`.
 
 After the `setup_workload_identity.sh` script finishes running, it will output a link to where you can edit your repository variables. Click on that link and then add the variables output from the script into your GitHub "Repository variables".

--- a/workflows/README.md
+++ b/workflows/README.md
@@ -27,7 +27,6 @@ Set the following environment variables in your repository:
 | GOOGLE_CLOUD_LOCATION     | Region of the Google Cloud project.                    | Variable | No       | When using Google Cloud            |
 | GOOGLE_GENAI_USE_VERTEXAI | Set to 'true' to use Vertex AI                         | Variable | No       | When using Vertex AI               |
 | GOOGLE_GENAI_USE_GCA      | Set to 'true' to use Gemini Code Assist                | Variable | No       | When using Gemini Code Assist      |
-
 | APP_ID                    | GitHub App ID for custom authentication.               | Variable | No       | When using a custom GitHub App     |
 
 SERVICE_ACCOUNT_EMAIL


### PR DESCRIPTION
The previous documentation for the `setup_workload_identity.sh` script was slightly ambiguous about what `OWNER` meant in the `<OWNER/REPO>` placeholder. This change clarifies that `OWNER` can be either a GitHub organization or a user's username, depending on the repository's ownership.

This improves clarity for users setting up Workload Identity Federation.
