### PR TITLE
fix(workflows): use GITHUB_TOKEN as fallback in scheduled triage

### DIFF
--- a/.github/workflows/gemini-issue-scheduled-triage.yml
+++ b/.github/workflows/gemini-issue-scheduled-triage.yml
@@ -69,7 +69,7 @@ jobs:
         uses: './'
         id: 'gemini_issue_triage'
         env:
-          GITHUB_TOKEN: '${{ steps.generate_token.outputs.token }}'
+          GITHUB_TOKEN: '${{ steps.generate_token.outputs.token || secrets.GITHUB_TOKEN }}'
           ISSUES_TO_TRIAGE: '${{ steps.find_issues.outputs.issues_to_triage }}'
           REPOSITORY: '${{ github.repository }}'
         with:

--- a/examples/workflows/issue-triage/gemini-issue-scheduled-triage.yml
+++ b/examples/workflows/issue-triage/gemini-issue-scheduled-triage.yml
@@ -69,7 +69,7 @@ jobs:
         uses: 'google-github-actions/run-gemini-cli@v0'
         id: 'gemini_issue_triage'
         env:
-          GITHUB_TOKEN: '${{ steps.generate_token.outputs.token }}'
+          GITHUB_TOKEN: '${{ steps.generate_token.outputs.token || secrets.GITHUB_TOKEN }}'
           ISSUES_TO_TRIAGE: '${{ steps.find_issues.outputs.issues_to_triage }}'
           REPOSITORY: '${{ github.repository }}'
         with:


### PR DESCRIPTION
  The scheduled issue triage workflow is designed to use a generated GitHub App token. If the "Generate GitHub App Token" step is skipped, the workflow would fail because the GITHUB_TOKEN environment variable would
  be empty.
