### PR TITLE
docs: fix workflow file path at setup section

### DIFF
--- a/examples/workflows/gemini-cli/README.md
+++ b/examples/workflows/gemini-cli/README.md
@@ -38,7 +38,7 @@ To use this workflow, you can utilize either of the following methods:
 
 ```bash
 mkdir -p .github/workflows
-curl -o .github/workflows/gemini-cli.yml https://raw.githubusercontent.com/google-github-actions/run-gemini-cli/main/workflows/gemini-cli/gemini-cli.yml
+curl -o .github/workflows/gemini-cli.yml https://raw.githubusercontent.com/google-github-actions/run-gemini-cli/main/examples/workflows/gemini-cli/gemini-cli.yml
 ```
 
 ## Usage

--- a/examples/workflows/issue-triage/README.md
+++ b/examples/workflows/issue-triage/README.md
@@ -41,8 +41,8 @@ To implement this issue triage system, you can utilize either of the following m
 
 ```bash
 mkdir -p .github/workflows
-curl -o .github/workflows/gemini-issue-automated-triage.yml https://raw.githubusercontent.com/google-github-actions/run-gemini-cli/main/workflows/issue-triage/gemini-issue-automated-triage.yml
-curl -o .github/workflows/gemini-issue-scheduled-triage.yml https://raw.githubusercontent.com/google-github-actions/run-gemini-cli/main/workflows/issue-triage/gemini-issue-scheduled-triage.yml
+curl -o .github/workflows/gemini-issue-automated-triage.yml https://raw.githubusercontent.com/google-github-actions/run-gemini-cli/main/examples/workflows/issue-triage/gemini-issue-automated-triage.yml
+curl -o .github/workflows/gemini-issue-scheduled-triage.yml https://raw.githubusercontent.com/google-github-actions/run-gemini-cli/main/examples/workflows/issue-triage/gemini-issue-scheduled-triage.yml
 ```
 
 You can customize the prompts and settings in the workflow files to suit your specific needs. For example, you can change the triage logic, the labels that are applied, or the schedule of the scheduled triage.

--- a/examples/workflows/pr-review/README.md
+++ b/examples/workflows/pr-review/README.md
@@ -50,7 +50,7 @@ To use this workflow, you can use either of the following methods:
 
 ```bash
 mkdir -p .github/workflows
-curl -o .github/workflows/gemini-pr-review.yml https://raw.githubusercontent.com/google-github-actions/run-gemini-cli/main/workflows/pr-review/gemini-pr-review.yml
+curl -o .github/workflows/gemini-pr-review.yml https://raw.githubusercontent.com/google-github-actions/run-gemini-cli/main/examples/workflows/pr-review/gemini-pr-review.yml
 ```
 
 ## Usage


### PR DESCRIPTION
## Summary

Documentation:
- Update curl command URLs in issue-triage, gemini-cli, and pr-review example READMEs to include the "examples" directory in the path