### PR TITLE
fix(workflows): review pull request from forked repo

### DIFF
--- a/.github/workflows/gemini-pr-review.yml
+++ b/.github/workflows/gemini-pr-review.yml
@@ -1,7 +1,7 @@
 name: '🧐 Gemini Pull Request Review'
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - 'opened'
   pull_request_review_comment:
@@ -36,7 +36,7 @@ jobs:
   review-pr:
     if: |-
       github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'pull_request' && github.event.action == 'opened') ||
+      (github.event_name == 'pull_request_target' && github.event.action == 'opened') ||
       (github.event_name == 'issue_comment' && github.event.issue.pull_request &&
         contains(github.event.comment.body, '@gemini-cli /review') &&
         (
@@ -77,10 +77,10 @@ jobs:
           app-id: '${{ vars.APP_ID }}'
           private-key: '${{ secrets.APP_PRIVATE_KEY }}'
 
-      - name: 'Get PR details (pull_request & workflow_dispatch)'
+      - name: 'Get PR details (pull_request_target & workflow_dispatch)'
         id: 'get_pr'
         if: |-
-          ${{ github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' }}
+          ${{ github.event_name == 'pull_request_target' || github.event_name == 'workflow_dispatch' }}
         env:
           GITHUB_TOKEN: '${{ steps.generate_token.outputs.token || secrets.GITHUB_TOKEN }}'
           EVENT_NAME: '${{ github.event_name }}'


### PR DESCRIPTION
## Summary

Bug Fixes:
- Update workflow trigger from `pull_request` to `pull_request_target` for PR review

## Why?

[🧐 Gemini Pull Request Review](https://github.com/google-github-actions/run-gemini-cli/blob/main/.github/workflows/gemini-pr-review.yml) doesn't run from a forked repository because default permission is `read`.

<img width="336" height="462" alt="image" src="https://github.com/user-attachments/assets/b25c9b37-0bae-431d-a823-1748a82b00d0" />

For example, [🧐 Gemini Pull Request Review](https://github.com/google-github-actions/run-gemini-cli/actions/runs/16768448309/job/47479130828?pr=106) was failed.