### PR TITLE
chore: change priority to severity

### DIFF
--- a/.github/workflows/gemini-pr-review.yml
+++ b/.github/workflows/gemini-pr-review.yml
@@ -387,15 +387,15 @@ jobs:
             1. Creating a pending review: Use the mcp__github__create_pending_pull_request_review to create a Pending Pull Request Review.
 
             2. Adding review comments:
-                2.1 Use the mcp__github__add_comment_to_pending_review to add comments to the Pending Pull Request Review. Inline comments are preffered whenever possible, so repeat this step, calling mcp__github__add_comment_to_pending_review, as needed. All comments about specific lines of code should use inline comments. It is preferred to use code suggestions when possible, which include a code block that is labeled "suggestion", which contains what the new code should be. All comments should also have a priority. They syntax is:
+                2.1 Use the mcp__github__add_comment_to_pending_review to add comments to the Pending Pull Request Review. Inline comments are preffered whenever possible, so repeat this step, calling mcp__github__add_comment_to_pending_review, as needed. All comments about specific lines of code should use inline comments. It is preferred to use code suggestions when possible, which include a code block that is labeled "suggestion", which contains what the new code should be. All comments should also have a severity. They syntax is:
                   Normal Comment Syntax:
                   <COMMENT>
-                  {{PRIORITY}} {{COMMENT_TEXT}}
+                  {{SEVERITY}} {{COMMENT_TEXT}}
                   </COMMENT>
 
                   Inline Comment Syntax: (Preferred):
                   <COMMENT>
-                  {{PRIORITY}} {{COMMENT_TEXT}}
+                  {{SEVERITY}} {{COMMENT_TEXT}}
                   ```suggestion
                   {{CODE_SUGGESTION}}
                   ```

--- a/examples/workflows/pr-review/gemini-pr-review.yml
+++ b/examples/workflows/pr-review/gemini-pr-review.yml
@@ -381,15 +381,15 @@ jobs:
             1. Creating a pending review: Use the mcp__github__create_pending_pull_request_review to create a Pending Pull Request Review.
 
             2. Adding review comments:
-                2.1 Use the mcp__github__add_comment_to_pending_review to add comments to the Pending Pull Request Review. Inline comments are preffered whenever possible, so repeat this step, calling mcp__github__add_comment_to_pending_review, as needed. All comments about specific lines of code should use inline comments. It is preferred to use code suggestions when possible, which include a code block that is labeled "suggestion", which contains what the new code should be. All comments should also have a priority. They syntax is:
+                2.1 Use the mcp__github__add_comment_to_pending_review to add comments to the Pending Pull Request Review. Inline comments are preffered whenever possible, so repeat this step, calling mcp__github__add_comment_to_pending_review, as needed. All comments about specific lines of code should use inline comments. It is preferred to use code suggestions when possible, which include a code block that is labeled "suggestion", which contains what the new code should be. All comments should also have a severity. They syntax is:
                   Normal Comment Syntax:
                   <COMMENT>
-                  {{PRIORITY}} {{COMMENT_TEXT}}
+                  {{SEVERITY}} {{COMMENT_TEXT}}
                   </COMMENT>
 
                   Inline Comment Syntax: (Preferred):
                   <COMMENT>
-                  {{PRIORITY}} {{COMMENT_TEXT}}
+                  {{SEVERITY}} {{COMMENT_TEXT}}
                   ```suggestion
                   {{CODE_SUGGESTION}}
                   ```


### PR DESCRIPTION
## Summary

Rename 'priority' field to 'severity' in the PR review workflow instructions

Documentation:
- Update .github/workflows/gemini-pr-review.yml to use 'severity' instead of 'priority' in comment syntax
- Update example workflow in examples/workflows/pr-review/gemini-pr-review.yml to replace 'priority' with 'severity'