### PR TITLE
fix(action): Unset empty gemini_api_key environment variable

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -140,7 +140,15 @@ runs:
       id: 'gemini_run'
       run: |-
         set -e
+
+        # Unset GEMINI_API_KEY if empty
+        if [ -z "${GEMINI_API_KEY}" ]; then
+          unset GEMINI_API_KEY
+        fi
+
+        # Run Gemini CLI with the provided prompt
         GEMINI_RESPONSE=$(gemini --yolo --prompt "${PROMPT}")
+
         # Set the captured response as a step output, supporting multiline
         echo "gemini_response<<EOF" >> "${GITHUB_OUTPUT}"
         echo "${GEMINI_RESPONSE}" >> "${GITHUB_OUTPUT}"


### PR DESCRIPTION
GitHub Actions defaults to passing an empty string for optional inputs that are not explicitly set in a workflow. When the `gemini_api_key` input is unset, it is passed as an empty string to the `GEMINI_API_KEY` environment variable.

The Gemini CLI does not handle an empty `GEMINI_API_KEY` variable gracefully, which can lead to unexpected behavior.

This commit addresses the issue by explicitly checking if the `GEMINI_API_KEY` variable is empty (`-z`). If it is, the variable is unset before invoking the Gemini CLI. This ensures the CLI's default authentication behavior (e.g., using Application Default Credentials) is triggered correctly when no API key is provided, improving the action's robustness and predictability.

>Note: This is a temporary workaround to unblock users. The underlying issue of handling empty string inputs will be addressed with improved validation in the Gemini CLI upstream.

Fixes: https://github.com/google-github-actions/run-gemini-cli/issues/123


