### PR TITLE
chore: mention user to confirm who run

### DIFF
--- a/.github/workflows/gemini-cli.yml
+++ b/.github/workflows/gemini-cli.yml
@@ -162,13 +162,14 @@ jobs:
 
       - name: 'Acknowledge request'
         env:
+          GITHUB_ACTOR: '${{ github.actor }}'
           GITHUB_TOKEN: '${{ steps.generate_token.outputs.token || secrets.GITHUB_TOKEN }}'
           ISSUE_NUMBER: '${{ steps.get_context.outputs.issue_number }}'
           REPOSITORY: '${{ github.repository }}'
           REQUEST_TYPE: '${{ steps.get_context.outputs.request_type }}'
         run: |-
           set -euo pipefail
-          MESSAGE="I've received your request and I'm working on it now! 🤖"
+          MESSAGE="@${GITHUB_ACTOR} I've received your request and I'm working on it now! 🤖"
           if [[ -n "${MESSAGE}" ]]; then
             gh issue comment "${ISSUE_NUMBER}" \
               --body "${MESSAGE}" \

--- a/examples/workflows/gemini-cli/gemini-cli.yml
+++ b/examples/workflows/gemini-cli/gemini-cli.yml
@@ -162,13 +162,14 @@ jobs:
 
       - name: 'Acknowledge request'
         env:
+          GITHUB_ACTOR: '${{ github.actor }}'
           GITHUB_TOKEN: '${{ steps.generate_token.outputs.token || secrets.GITHUB_TOKEN }}'
           ISSUE_NUMBER: '${{ steps.get_context.outputs.issue_number }}'
           REPOSITORY: '${{ github.repository }}'
           REQUEST_TYPE: '${{ steps.get_context.outputs.request_type }}'
         run: |-
           set -euo pipefail
-          MESSAGE="I've received your request and I'm working on it now! 🤖"
+          MESSAGE="@${GITHUB_ACTOR} I've received your request and I'm working on it now! 🤖"
           if [[ -n "${MESSAGE}" ]]; then
             gh issue comment "${ISSUE_NUMBER}" \
               --body "${MESSAGE}" \


### PR DESCRIPTION
## Summary

Update Gemini CLI workflows to mention the actor when posting acknowledgment comments

Enhancements:
- Add GITHUB_ACTOR environment variable to workflows
- Prefix acknowledgment messages with the @mention of the GitHub actor

## Why?

This is to confirm who responded when multiple people called within the organization.
This is also useful for checking which users have the authority to perform actions.

## How to verify your codes?

I've tested this workflow with issue and pull request comments.

<img width="1013" height="159" alt="image" src="https://github.com/user-attachments/assets/e37785b5-2c06-4b56-8c0d-51b9df95ccb3" />