### PR TITLE
bug(#109): Support triggering PR review with issue comment

### DIFF
--- a/.github/workflows/gemini-pr-review.yml
+++ b/.github/workflows/gemini-pr-review.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types:
       - 'opened'
+  issue_comment:
+    types:
+      - 'created'
   pull_request_review_comment:
     types:
       - 'created'

--- a/examples/workflows/pr-review/gemini-pr-review.yml
+++ b/examples/workflows/pr-review/gemini-pr-review.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types:
       - 'opened'
+  issue_comment:
+    types:
+      - 'created'
   pull_request_review_comment:
     types:
       - 'created'


### PR DESCRIPTION
Fix PR workflow to be triggered when users comments `@gemini /review` in a PR

Fixes #109 