### PR TITLE
Add `echo` to core tools for automated issue triage

### DIFF
--- a/.github/workflows/gemini-issue-automated-triage.yml
+++ b/.github/workflows/gemini-issue-automated-triage.yml
@@ -77,6 +77,7 @@ jobs:
             {
               "maxSessionTurns": 25,
               "coreTools": [
+                "run_shell_command(echo)",
                 "run_shell_command(gh label list)",
                 "run_shell_command(gh issue edit)"
               ],

--- a/examples/workflows/issue-triage/gemini-issue-automated-triage.yml
+++ b/examples/workflows/issue-triage/gemini-issue-automated-triage.yml
@@ -77,6 +77,7 @@ jobs:
             {
               "maxSessionTurns": 25,
               "coreTools": [
+                "run_shell_command(echo)",
                 "run_shell_command(gh label list)",
                 "run_shell_command(gh issue edit)"
               ],


### PR DESCRIPTION
This will help make sure it can access the issue title and body.

Example run needing `echo`: https://github.com/google-github-actions/run-gemini-cli/actions/runs/16816912109/job/47635803167

Note that scheduled triage has `echo` tool already.

cc @leehagoodjames 
