### PR TITLE
fix: output interruption after first response

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -147,7 +147,16 @@ runs:
         fi
 
         # Run Gemini CLI with the provided prompt
-        GEMINI_RESPONSE=$(gemini --yolo --prompt "${PROMPT}")
+        TEMP_OUTPUT=$(mktemp)
+        if gemini --yolo --debug --prompt "${PROMPT}" > "${TEMP_OUTPUT}" 2>&1; then
+          GEMINI_RESPONSE=$(cat "${TEMP_OUTPUT}")
+        else
+          echo "Error: Gemini CLI execution failed"
+          cat "${TEMP_OUTPUT}"
+          rm -f "${TEMP_OUTPUT}"
+          exit 1
+        fi
+        rm -f "${TEMP_OUTPUT}"
 
         # Set the captured response as a step output, supporting multiline
         echo "gemini_response<<EOF" >> "${GITHUB_OUTPUT}"


### PR DESCRIPTION
<!--
Thank you for proposing a pull request! Please note that SOME TESTS WILL
LIKELY FAIL due to how GitHub exposes secrets in Pull Requests from forks.
Someone from the team will review your Pull Request and respond.

Please describe your change and any implementation details below.
-->

Problem
The Gemini CLI command was stopping early when capturing output using direct shell command substitution ($(gemini ...)), likely due to buffering issues or incomplete output capture.

Solution
Replaced the direct command substitution with a more robust approach:

Temporary file capture: Uses mktemp to create a temporary file for capturing the full output
Explicit error handling: Added proper exit code checking to distinguish between success and failure
Complete output capture: Captures both stdout and stderr (2>&1) to ensure no output is lost
Proper cleanup: Temporary files are cleaned up after use