### PR TITLE
feat(workflows): reduce restrictions for invoking workflows for private repos

### DIFF
--- a/.github/workflows/gemini-cli.yml
+++ b/.github/workflows/gemini-cli.yml
@@ -28,7 +28,9 @@ permissions:
 
 jobs:
   gemini-cli:
-    # This condition is complex to ensure we only run when explicitly invoked.
+    # This condition seeks to ensure the action is only run when it is triggered by a trusted user.
+    # For private repos, users who have access to the repo are considered trusted.
+    # For public repos, users who members, owners, or collaborators are considered trusted.
     if: |-
       github.event_name == 'workflow_dispatch' ||
       (
@@ -36,7 +38,10 @@ jobs:
         contains(github.event.issue.body, '@gemini-cli') &&
         !contains(github.event.issue.body, '@gemini-cli /review') &&
         !contains(github.event.issue.body, '@gemini-cli /triage') &&
-        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.issue.author_association)
+        (
+          github.event.repository.private == true ||
+          contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.issue.author_association)
+        )
       ) ||
       (
         (
@@ -46,14 +51,20 @@ jobs:
         contains(github.event.comment.body, '@gemini-cli') &&
         !contains(github.event.comment.body, '@gemini-cli /review') &&
         !contains(github.event.comment.body, '@gemini-cli /triage') &&
-        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
+        (
+          github.event.repository.private == true ||
+          contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
+        )
       ) ||
       (
         github.event_name == 'pull_request_review' &&
         contains(github.event.review.body, '@gemini-cli') &&
         !contains(github.event.review.body, '@gemini-cli /review') &&
         !contains(github.event.review.body, '@gemini-cli /triage') &&
-        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.review.author_association)
+        (
+          github.event.repository.private == true ||
+          contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.review.author_association)
+        )
       )
     timeout-minutes: 10
     runs-on: 'ubuntu-latest'

--- a/.github/workflows/gemini-pr-review.yml
+++ b/.github/workflows/gemini-pr-review.yml
@@ -38,11 +38,17 @@ permissions:
 
 jobs:
   review-pr:
+    # This condition seeks to ensure the action is only run when it is triggered by a trusted user.
+    # For private repos, users who have access to the repo are considered trusted.
+    # For public repos, users who members, owners, or collaborators are considered trusted.
     if: |-
       github.event_name == 'workflow_dispatch' ||
       (
         github.event_name == 'pull_request' &&
-        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association)
+        (
+          github.event.repository.private == true ||
+          contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association)
+        )
       ) ||
       (
         (
@@ -53,12 +59,18 @@ jobs:
           github.event_name == 'pull_request_review_comment'
         ) &&
         contains(github.event.comment.body, '@gemini-cli /review') &&
-        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
+        (
+          github.event.repository.private == true ||
+          contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
+        )
       ) ||
       (
         github.event_name == 'pull_request_review' &&
         contains(github.event.review.body, '@gemini-cli /review') &&
-        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.review.author_association)
+        (
+          github.event.repository.private == true ||
+          contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.review.author_association)
+        )
       )
     timeout-minutes: 5
     runs-on: 'ubuntu-latest'

--- a/examples/workflows/gemini-cli/gemini-cli.yml
+++ b/examples/workflows/gemini-cli/gemini-cli.yml
@@ -28,7 +28,9 @@ permissions:
 
 jobs:
   gemini-cli:
-    # This condition is complex to ensure we only run when explicitly invoked.
+    # This condition seeks to ensure the action is only run when it is triggered by a trusted user.
+    # For private repos, users who have access to the repo are considered trusted.
+    # For public repos, users who members, owners, or collaborators are considered trusted.
     if: |-
       github.event_name == 'workflow_dispatch' ||
       (
@@ -36,7 +38,10 @@ jobs:
         contains(github.event.issue.body, '@gemini-cli') &&
         !contains(github.event.issue.body, '@gemini-cli /review') &&
         !contains(github.event.issue.body, '@gemini-cli /triage') &&
-        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.issue.author_association)
+        (
+          github.event.repository.private == true ||
+          contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.issue.author_association)
+        )
       ) ||
       (
         (
@@ -46,14 +51,20 @@ jobs:
         contains(github.event.comment.body, '@gemini-cli') &&
         !contains(github.event.comment.body, '@gemini-cli /review') &&
         !contains(github.event.comment.body, '@gemini-cli /triage') &&
-        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
+        (
+          github.event.repository.private == true ||
+          contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
+        )
       ) ||
       (
         github.event_name == 'pull_request_review' &&
         contains(github.event.review.body, '@gemini-cli') &&
         !contains(github.event.review.body, '@gemini-cli /review') &&
         !contains(github.event.review.body, '@gemini-cli /triage') &&
-        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.review.author_association)
+        (
+          github.event.repository.private == true ||
+          contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.review.author_association)
+        )
       )
     timeout-minutes: 10
     runs-on: 'ubuntu-latest'

--- a/examples/workflows/pr-review/gemini-pr-review.yml
+++ b/examples/workflows/pr-review/gemini-pr-review.yml
@@ -38,11 +38,17 @@ permissions:
 
 jobs:
   review-pr:
+    # This condition seeks to ensure the action is only run when it is triggered by a trusted user.
+    # For private repos, users who have access to the repo are considered trusted.
+    # For public repos, users who members, owners, or collaborators are considered trusted.
     if: |-
       github.event_name == 'workflow_dispatch' ||
       (
         github.event_name == 'pull_request' &&
-        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association)
+        (
+          github.event.repository.private == true ||
+          contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association)
+        )
       ) ||
       (
         (
@@ -53,12 +59,18 @@ jobs:
           github.event_name == 'pull_request_review_comment'
         ) &&
         contains(github.event.comment.body, '@gemini-cli /review') &&
-        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
+        (
+          github.event.repository.private == true ||
+          contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
+        )
       ) ||
       (
         github.event_name == 'pull_request_review' &&
         contains(github.event.review.body, '@gemini-cli /review') &&
-        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.review.author_association)
+        (
+          github.event.repository.private == true ||
+          contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.review.author_association)
+        )
       )
     timeout-minutes: 5
     runs-on: 'ubuntu-latest'


### PR DESCRIPTION
The workflows for https://github.com/google-github-actions/run-gemini-cli enable restrictions on who can invoke them, to prevent abuse scenarios by untrusted users. 

A better solution would enable reliably checking repository membership with `github.event.issue.author_association`, but this is not possible since `github.event.issue.author_association` can return `CONTRIBUTOR` even when the author is also a `MEMBER`. Given this, https://github.com/actions/github-script/issues/643 has been filed with GitHub to allow actions to more easily check for membership. 

This mitigation simplifies the experience for private repos

Fixes #163 