### PR TITLE
feat(logging): Enable debug logging across all workflows and gemini-cli

### DIFF
--- a/.github/workflows/gemini-cli.yml
+++ b/.github/workflows/gemini-cli.yml
@@ -57,6 +57,8 @@ jobs:
       )
     timeout-minutes: 10
     runs-on: 'ubuntu-latest'
+    env:
+      ACTIONS_STEP_DEBUG: true # Default to debug logging
 
     steps:
       - name: 'Generate GitHub App Token'
@@ -203,8 +205,10 @@ jobs:
           gcp_service_account: '${{ vars.SERVICE_ACCOUNT_EMAIL }}'
           use_vertex_ai: '${{ vars.GOOGLE_GENAI_USE_VERTEXAI }}'
           use_gemini_code_assist: '${{ vars.GOOGLE_GENAI_USE_GCA }}'
+          # Default to debug logging. Disable debug logging by removing '"debug": true,'
           settings: |-
             {
+              "debug": true,
               "maxSessionTurns": 50,
               "telemetry": {
                 "enabled": true,

--- a/.github/workflows/gemini-issue-automated-triage.yml
+++ b/.github/workflows/gemini-issue-automated-triage.yml
@@ -41,6 +41,8 @@ jobs:
       )
     timeout-minutes: 5
     runs-on: 'ubuntu-latest'
+    env:
+      ACTIONS_STEP_DEBUG: true # Default to debug logging
 
     steps:
       - name: 'Checkout repository'
@@ -73,8 +75,10 @@ jobs:
           gemini_api_key: '${{ secrets.GEMINI_API_KEY }}'
           use_vertex_ai: '${{ vars.GOOGLE_GENAI_USE_VERTEXAI }}'
           use_gemini_code_assist: '${{ vars.GOOGLE_GENAI_USE_GCA }}'
+          # Default to debug logging. Disable debug logging by removing '"debug": true,'
           settings: |-
             {
+              "debug": true,
               "maxSessionTurns": 25,
               "coreTools": [
                 "run_shell_command(echo)",

--- a/.github/workflows/gemini-issue-scheduled-triage.yml
+++ b/.github/workflows/gemini-issue-scheduled-triage.yml
@@ -23,6 +23,8 @@ jobs:
   triage-issues:
     timeout-minutes: 5
     runs-on: 'ubuntu-latest'
+    env:
+      ACTIONS_STEP_DEBUG: true # Default to debug logging
 
     steps:
       - name: 'Checkout repository'
@@ -81,8 +83,10 @@ jobs:
           gemini_api_key: '${{ secrets.GEMINI_API_KEY }}'
           use_vertex_ai: '${{ vars.GOOGLE_GENAI_USE_VERTEXAI }}'
           use_gemini_code_assist: '${{ vars.GOOGLE_GENAI_USE_GCA }}'
+          # Default to debug logging. Disable debug logging by removing '"debug": true,'
           settings: |-
             {
+              "debug": true,
               "maxSessionTurns": 25,
               "coreTools": [
                 "run_shell_command(echo)",

--- a/.github/workflows/gemini-pr-review.yml
+++ b/.github/workflows/gemini-pr-review.yml
@@ -62,6 +62,8 @@ jobs:
       )
     timeout-minutes: 5
     runs-on: 'ubuntu-latest'
+    env:
+      ACTIONS_STEP_DEBUG: true # Default to debug logging
 
     steps:
       - name: 'Checkout PR code'
@@ -159,8 +161,10 @@ jobs:
           gemini_api_key: '${{ secrets.GEMINI_API_KEY }}'
           use_vertex_ai: '${{ vars.GOOGLE_GENAI_USE_VERTEXAI }}'
           use_gemini_code_assist: '${{ vars.GOOGLE_GENAI_USE_GCA }}'
+          # Default to debug logging. Disable debug logging by removing '"debug": true,'
           settings: |-
             {
+              "debug": true,
               "maxSessionTurns": 20,
               "mcpServers": {
                 "github": {

--- a/examples/workflows/gemini-cli/gemini-cli.yml
+++ b/examples/workflows/gemini-cli/gemini-cli.yml
@@ -57,6 +57,8 @@ jobs:
       )
     timeout-minutes: 10
     runs-on: 'ubuntu-latest'
+    env:
+      ACTIONS_STEP_DEBUG: true # Default to debug logging
 
     steps:
       - name: 'Generate GitHub App Token'
@@ -203,8 +205,10 @@ jobs:
           gcp_service_account: '${{ vars.SERVICE_ACCOUNT_EMAIL }}'
           use_vertex_ai: '${{ vars.GOOGLE_GENAI_USE_VERTEXAI }}'
           use_gemini_code_assist: '${{ vars.GOOGLE_GENAI_USE_GCA }}'
+          # Default to debug logging. Disable debug logging by removing '"debug": true,'
           settings: |-
             {
+              "debug": true,
               "maxSessionTurns": 50,
               "telemetry": {
                 "enabled": false,

--- a/examples/workflows/issue-triage/gemini-issue-automated-triage.yml
+++ b/examples/workflows/issue-triage/gemini-issue-automated-triage.yml
@@ -41,6 +41,8 @@ jobs:
       )
     timeout-minutes: 5
     runs-on: 'ubuntu-latest'
+    env:
+      ACTIONS_STEP_DEBUG: true # Default to debug logging
 
     steps:
       - name: 'Checkout repository'
@@ -73,8 +75,10 @@ jobs:
           gemini_api_key: '${{ secrets.GEMINI_API_KEY }}'
           use_vertex_ai: '${{ vars.GOOGLE_GENAI_USE_VERTEXAI }}'
           use_gemini_code_assist: '${{ vars.GOOGLE_GENAI_USE_GCA }}'
+          # Default to debug logging. Disable debug logging by removing '"debug": true,'
           settings: |-
             {
+              "debug": true,
               "maxSessionTurns": 25,
               "coreTools": [
                 "run_shell_command(echo)",

--- a/examples/workflows/issue-triage/gemini-issue-scheduled-triage.yml
+++ b/examples/workflows/issue-triage/gemini-issue-scheduled-triage.yml
@@ -23,6 +23,8 @@ jobs:
   triage-issues:
     timeout-minutes: 5
     runs-on: 'ubuntu-latest'
+    env:
+      ACTIONS_STEP_DEBUG: true # Default to debug logging
 
     steps:
       - name: 'Checkout repository'
@@ -81,8 +83,10 @@ jobs:
           gemini_api_key: '${{ secrets.GEMINI_API_KEY }}'
           use_vertex_ai: '${{ vars.GOOGLE_GENAI_USE_VERTEXAI }}'
           use_gemini_code_assist: '${{ vars.GOOGLE_GENAI_USE_GCA }}'
+          # Default to debug logging. Disable debug logging by removing '"debug": true,'
           settings: |-
             {
+              "debug": true,
               "maxSessionTurns": 25,
               "coreTools": [
                 "run_shell_command(echo)",

--- a/examples/workflows/pr-review/gemini-pr-review.yml
+++ b/examples/workflows/pr-review/gemini-pr-review.yml
@@ -62,6 +62,8 @@ jobs:
       )
     timeout-minutes: 5
     runs-on: 'ubuntu-latest'
+    env:
+      ACTIONS_STEP_DEBUG: true # Default to debug logging
 
     steps:
       - name: 'Checkout PR code'
@@ -159,8 +161,10 @@ jobs:
           gemini_api_key: '${{ secrets.GEMINI_API_KEY }}'
           use_vertex_ai: '${{ vars.GOOGLE_GENAI_USE_VERTEXAI }}'
           use_gemini_code_assist: '${{ vars.GOOGLE_GENAI_USE_GCA }}'
+          # Default to debug logging. Disable debug logging by removing '"debug": true,'
           settings: |-
             {
+              "debug": true,
               "maxSessionTurns": 20,
               "mcpServers": {
                 "github": {


### PR DESCRIPTION
Numerous issues have complained about unexpected workflow exits. In response, some users submit these logs as part of their issue (ex: #137). 

However, without debug logging enabled, the logs don't show anything useful.

This change opts for debugging logging by default, and informs the user how to disable it. 

Related to: #133, #137, #174, 