### PR TITLE
chore(logging): only enable Gemini debug when DEBUG is set

### DIFF
--- a/.github/workflows/gemini-cli.yml
+++ b/.github/workflows/gemini-cli.yml
@@ -68,9 +68,6 @@ jobs:
       )
     timeout-minutes: 10
     runs-on: 'ubuntu-latest'
-    env:
-      ACTIONS_STEP_DEBUG: true # Default to debug logging
-
     steps:
       - name: 'Generate GitHub App Token'
         id: 'generate_token'
@@ -216,10 +213,9 @@ jobs:
           gcp_service_account: '${{ vars.SERVICE_ACCOUNT_EMAIL }}'
           use_vertex_ai: '${{ vars.GOOGLE_GENAI_USE_VERTEXAI }}'
           use_gemini_code_assist: '${{ vars.GOOGLE_GENAI_USE_GCA }}'
-          # Default to debug logging. Disable debug logging by removing '"debug": true,'
           settings: |-
             {
-              "debug": true,
+              "debug": ${{ fromJSON(env.DEBUG || env.ACTIONS_STEP_DEBUG || false) }},
               "maxSessionTurns": 50,
               "telemetry": {
                 "enabled": true,

--- a/.github/workflows/gemini-issue-automated-triage.yml
+++ b/.github/workflows/gemini-issue-automated-triage.yml
@@ -41,9 +41,6 @@ jobs:
       )
     timeout-minutes: 5
     runs-on: 'ubuntu-latest'
-    env:
-      ACTIONS_STEP_DEBUG: true # Default to debug logging
-
     steps:
       - name: 'Checkout repository'
         uses: 'actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683' # ratchet:actions/checkout@v4
@@ -75,10 +72,9 @@ jobs:
           gemini_api_key: '${{ secrets.GEMINI_API_KEY }}'
           use_vertex_ai: '${{ vars.GOOGLE_GENAI_USE_VERTEXAI }}'
           use_gemini_code_assist: '${{ vars.GOOGLE_GENAI_USE_GCA }}'
-          # Default to debug logging. Disable debug logging by removing '"debug": true,'
           settings: |-
             {
-              "debug": true,
+              "debug": ${{ fromJSON(env.DEBUG || env.ACTIONS_STEP_DEBUG || false) }},
               "maxSessionTurns": 25,
               "coreTools": [
                 "run_shell_command(echo)",

--- a/.github/workflows/gemini-issue-scheduled-triage.yml
+++ b/.github/workflows/gemini-issue-scheduled-triage.yml
@@ -23,9 +23,6 @@ jobs:
   triage-issues:
     timeout-minutes: 5
     runs-on: 'ubuntu-latest'
-    env:
-      ACTIONS_STEP_DEBUG: true # Default to debug logging
-
     steps:
       - name: 'Checkout repository'
         uses: 'actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683' # ratchet:actions/checkout@v4
@@ -83,10 +80,9 @@ jobs:
           gemini_api_key: '${{ secrets.GEMINI_API_KEY }}'
           use_vertex_ai: '${{ vars.GOOGLE_GENAI_USE_VERTEXAI }}'
           use_gemini_code_assist: '${{ vars.GOOGLE_GENAI_USE_GCA }}'
-          # Default to debug logging. Disable debug logging by removing '"debug": true,'
           settings: |-
             {
-              "debug": true,
+              "debug": ${{ fromJSON(env.DEBUG || env.ACTIONS_STEP_DEBUG || false) }},
               "maxSessionTurns": 25,
               "coreTools": [
                 "run_shell_command(echo)",

--- a/.github/workflows/gemini-pr-review.yml
+++ b/.github/workflows/gemini-pr-review.yml
@@ -74,9 +74,6 @@ jobs:
       )
     timeout-minutes: 5
     runs-on: 'ubuntu-latest'
-    env:
-      ACTIONS_STEP_DEBUG: true # Default to debug logging
-
     steps:
       - name: 'Checkout PR code'
         uses: 'actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683' # ratchet:actions/checkout@v4
@@ -173,10 +170,9 @@ jobs:
           gemini_api_key: '${{ secrets.GEMINI_API_KEY }}'
           use_vertex_ai: '${{ vars.GOOGLE_GENAI_USE_VERTEXAI }}'
           use_gemini_code_assist: '${{ vars.GOOGLE_GENAI_USE_GCA }}'
-          # Default to debug logging. Disable debug logging by removing '"debug": true,'
           settings: |-
             {
-              "debug": true,
+              "debug": ${{ fromJSON(env.DEBUG || env.ACTIONS_STEP_DEBUG || false) }},
               "maxSessionTurns": 20,
               "mcpServers": {
                 "github": {

--- a/examples/workflows/gemini-cli/gemini-cli.yml
+++ b/examples/workflows/gemini-cli/gemini-cli.yml
@@ -68,9 +68,6 @@ jobs:
       )
     timeout-minutes: 10
     runs-on: 'ubuntu-latest'
-    env:
-      ACTIONS_STEP_DEBUG: true # Default to debug logging
-
     steps:
       - name: 'Generate GitHub App Token'
         id: 'generate_token'
@@ -216,10 +213,9 @@ jobs:
           gcp_service_account: '${{ vars.SERVICE_ACCOUNT_EMAIL }}'
           use_vertex_ai: '${{ vars.GOOGLE_GENAI_USE_VERTEXAI }}'
           use_gemini_code_assist: '${{ vars.GOOGLE_GENAI_USE_GCA }}'
-          # Default to debug logging. Disable debug logging by removing '"debug": true,'
           settings: |-
             {
-              "debug": true,
+              "debug": ${{ fromJSON(env.DEBUG || env.ACTIONS_STEP_DEBUG || false) }},
               "maxSessionTurns": 50,
               "telemetry": {
                 "enabled": false,

--- a/examples/workflows/issue-triage/gemini-issue-automated-triage.yml
+++ b/examples/workflows/issue-triage/gemini-issue-automated-triage.yml
@@ -41,9 +41,6 @@ jobs:
       )
     timeout-minutes: 5
     runs-on: 'ubuntu-latest'
-    env:
-      ACTIONS_STEP_DEBUG: true # Default to debug logging
-
     steps:
       - name: 'Checkout repository'
         uses: 'actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683' # ratchet:actions/checkout@v4
@@ -75,10 +72,9 @@ jobs:
           gemini_api_key: '${{ secrets.GEMINI_API_KEY }}'
           use_vertex_ai: '${{ vars.GOOGLE_GENAI_USE_VERTEXAI }}'
           use_gemini_code_assist: '${{ vars.GOOGLE_GENAI_USE_GCA }}'
-          # Default to debug logging. Disable debug logging by removing '"debug": true,'
           settings: |-
             {
-              "debug": true,
+              "debug": ${{ fromJSON(env.DEBUG || env.ACTIONS_STEP_DEBUG || false) }},
               "maxSessionTurns": 25,
               "coreTools": [
                 "run_shell_command(echo)",

--- a/examples/workflows/issue-triage/gemini-issue-scheduled-triage.yml
+++ b/examples/workflows/issue-triage/gemini-issue-scheduled-triage.yml
@@ -23,9 +23,6 @@ jobs:
   triage-issues:
     timeout-minutes: 5
     runs-on: 'ubuntu-latest'
-    env:
-      ACTIONS_STEP_DEBUG: true # Default to debug logging
-
     steps:
       - name: 'Checkout repository'
         uses: 'actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683' # ratchet:actions/checkout@v4
@@ -83,10 +80,9 @@ jobs:
           gemini_api_key: '${{ secrets.GEMINI_API_KEY }}'
           use_vertex_ai: '${{ vars.GOOGLE_GENAI_USE_VERTEXAI }}'
           use_gemini_code_assist: '${{ vars.GOOGLE_GENAI_USE_GCA }}'
-          # Default to debug logging. Disable debug logging by removing '"debug": true,'
           settings: |-
             {
-              "debug": true,
+              "debug": ${{ fromJSON(env.DEBUG || env.ACTIONS_STEP_DEBUG || false) }},
               "maxSessionTurns": 25,
               "coreTools": [
                 "run_shell_command(echo)",

--- a/examples/workflows/pr-review/gemini-pr-review.yml
+++ b/examples/workflows/pr-review/gemini-pr-review.yml
@@ -74,9 +74,6 @@ jobs:
       )
     timeout-minutes: 5
     runs-on: 'ubuntu-latest'
-    env:
-      ACTIONS_STEP_DEBUG: true # Default to debug logging
-
     steps:
       - name: 'Checkout PR code'
         uses: 'actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683' # ratchet:actions/checkout@v4
@@ -173,10 +170,9 @@ jobs:
           gemini_api_key: '${{ secrets.GEMINI_API_KEY }}'
           use_vertex_ai: '${{ vars.GOOGLE_GENAI_USE_VERTEXAI }}'
           use_gemini_code_assist: '${{ vars.GOOGLE_GENAI_USE_GCA }}'
-          # Default to debug logging. Disable debug logging by removing '"debug": true,'
           settings: |-
             {
-              "debug": true,
+              "debug": ${{ fromJSON(env.DEBUG || env.ACTIONS_STEP_DEBUG || false) }},
               "maxSessionTurns": 20,
               "mcpServers": {
                 "github": {


### PR DESCRIPTION
This is a follow-up to #178 which sets the Gemini CLI debug settings.