### PR TITLE
docs: add gitignore recommendations across all workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,9 @@ Use it to perform GitHub pull request reviews, triage issues, perform code analy
   - [Quick Start](#quick-start)
     - [1. Get a Gemini API Key](#1-get-a-gemini-api-key)
     - [2. Add it as a GitHub Secret](#2-add-it-as-a-github-secret)
-    - [3. Choose a Workflow](#3-choose-a-workflow)
-    - [4. Try it out!](#4-try-it-out)
+    - [3. Update your .gitignore](#3-update-your-gitignore)
+    - [4. Choose a Workflow](#4-choose-a-workflow)
+    - [5. Try it out!](#5-try-it-out)
   - [Workflows](#workflows)
     - [Issue Triage](#issue-triage)
     - [Pull Request Review](#pull-request-review)
@@ -52,17 +53,28 @@ Store your API key as a secret named `GEMINI_API_KEY` in your repository:
 - Click **New repository secret**
 - Name: `GEMINI_API_KEY`, Value: your API key
 
-### 3. Choose a Workflow
+### 3. Update your .gitignore
+Add the following entries to your `.gitignore` file:
+
+```gitignore
+# gemini-cli settings
+.gemini/
+
+# GitHub App credentials
+gha-creds-*.json
+```
+
+### 4. Choose a Workflow
 You have two options to set up a workflow:
 
 **Option A: Use setup command (Recommended)**
-1. Start the Gemini CLI:
+1. Start the Gemini CLI in your terminal:
 
    ```shell
    gemini
    ```
 
-2. In the chat interface, type:
+2. In Gemini CLI in your terminal, type:
 
    ```
    /setup-github
@@ -71,7 +83,7 @@ You have two options to set up a workflow:
 **Option B: Manually copy workflows**
 1. Copy the pre-built workflows from the [`examples/workflows`](./examples/workflows) directory to your repository's `.github/workflows` directory.
 
-### 4. Try it out!
+### 5. Try it out!
 
 **Pull Request Review:**
 - Open a pull request in your repository and wait for automatic review

--- a/examples/workflows/gemini-cli/README.md
+++ b/examples/workflows/gemini-cli/README.md
@@ -6,6 +6,8 @@ In this guide you will learn how to use the Gemini CLI Assistant via GitHub Acti
   - [Overview](#overview)
   - [Features](#features)
   - [Setup](#setup)
+    - [Prerequisites](#prerequisites)
+    - [Setup Methods](#setup-methods)
   - [Usage](#usage)
     - [Supported Triggers](#supported-triggers)
     - [How to Invoke the Gemini CLI Workflow](#how-to-invoke-the-gemini-cli-workflow)
@@ -31,6 +33,20 @@ Unlike specialized Gemini CLI workflows for [pull request reviews](../pr-review)
 ## Setup
 
 For detailed setup instructions, including prerequisites and authentication, please refer to the main [Getting Started](../../../README.md#quick-start) section and [Authentication documentation](../../../docs/authentication.md).
+
+### Prerequisites
+
+Add the following entries to your `.gitignore` file to prevent Gemini CLI artifacts from being committed:
+
+```gitignore
+# gemini-cli settings
+.gemini/
+
+# GitHub App credentials
+gha-creds-*.json
+```
+
+### Setup Methods
 
 To use this workflow, you can utilize either of the following methods:
 1. Run the `/setup-github` command in Gemini CLI on your terminal to set up workflows for your repository.

--- a/examples/workflows/issue-triage/README.md
+++ b/examples/workflows/issue-triage/README.md
@@ -6,6 +6,8 @@ This document describes a comprehensive system for triaging GitHub issues using 
   - [Overview](#overview)
   - [Features](#features)
   - [Setup](#setup)
+    - [Prerequisites](#prerequisites)
+    - [Setup Methods](#setup-methods)
   - [Usage](#usage)
     - [Supported Triggers](#supported-triggers)
     - [Real-Time Issue Triage](#real-time-issue-triage)
@@ -34,6 +36,20 @@ The Issue Triage workflows provide an automated system for analyzing and categor
 ## Setup
 
 For detailed setup instructions, including prerequisites and authentication, please refer to the main [Getting Started](../../../README.md#quick-start) section and [Authentication documentation](../../../docs/authentication.md).
+
+### Prerequisites
+
+Add the following entries to your `.gitignore` file to prevent issue triage artifacts from being committed:
+
+```gitignore
+# gemini-cli settings
+.gemini/
+
+# GitHub App credentials
+gha-creds-*.json
+```
+
+### Setup Methods
 
 To implement this issue triage system, you can utilize either of the following methods:
 1. Run the `/setup-github` command in Gemini CLI on your terminal to set up workflows for your repository.

--- a/examples/workflows/pr-review/README.md
+++ b/examples/workflows/pr-review/README.md
@@ -6,6 +6,8 @@ This document explains how to use the Gemini CLI on GitHub to automatically revi
   - [Overview](#overview)
   - [Features](#features)
   - [Setup](#setup)
+    - [Prerequisites](#prerequisites)
+    - [Setup Methods](#setup-methods)
   - [Usage](#usage)
     - [Supported Triggers](#supported-triggers)
   - [Interaction Flow](#interaction-flow)
@@ -43,6 +45,20 @@ The PR Review workflow uses Google's Gemini AI to provide comprehensive code rev
 ## Setup
 
 For detailed setup instructions, including prerequisites and authentication, please refer to the main [Getting Started](../../../README.md#quick-start) section and [Authentication documentation](../../../docs/authentication.md).
+
+### Prerequisites
+
+Add the following entries to your `.gitignore` file to prevent PR review artifacts from being committed:
+
+```gitignore
+# gemini-cli settings
+.gemini/
+
+# GitHub App credentials
+gha-creds-*.json
+```
+
+### Setup Methods
 
 To use this workflow, you can use either of the following methods:
 1. Run the `/setup-github` command in Gemini CLI on your terminal to set up workflows for your repository.


### PR DESCRIPTION
- Add .gitignore step to all setup instructions
- Include `.gemini/` and `gha-creds-*.json` entries

Note: Will update /setup-github command to handle gitignore automatically

https://github.com/google-github-actions/run-gemini-cli/issues/196

