### PR TITLE
bug(output): do not print output by default

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -167,22 +167,12 @@ runs:
 
         GEMINI_RESPONSE="$(cat "${TEMP_STDOUT}")"
 
-        # Print the response
-        echo "::group::Gemini response"
-        echo "${GEMINI_RESPONSE}"
-        echo "::endgroup::"
-
         # Set the captured response as a step output, supporting multiline
         echo "gemini_response<<EOF" >> "${GITHUB_OUTPUT}"
         echo "${GEMINI_RESPONSE}" >> "${GITHUB_OUTPUT}"
         echo "EOF" >> "${GITHUB_OUTPUT}"
 
         GEMINI_ERRORS="$(cat "${TEMP_STDERR}")"
-
-        # Print any errors
-        echo "::group::Gemini error messages"
-        echo "${GEMINI_ERRORS}"
-        echo "::endgroup::"
 
         # Set the captured errors as a step output, supporting multiline
         echo "gemini_errors<<EOF" >> "${GITHUB_OUTPUT}"


### PR DESCRIPTION
It's possible to trick the LLM into printing sensitive information from the environment like access keys or credentials. While GitHub Actions secret masking + shell_command restrictions provide some protections, the best protection is to suppress Gemini CLI output in the logs. The output is still accessible via the `summary` and `error` fields on the GitHub Action, in case later steps do want to print or inspect the output.
