### PR TITLE
Fix live streaming output whilst preserving stdout/stderr separation

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -161,7 +161,7 @@ runs:
 
         # Run Gemini CLI with the provided prompt
         FAILED=false
-        if ! gemini --yolo --prompt "${PROMPT}" 2> "${TEMP_STDERR}" 1> "${TEMP_STDOUT}"; then
+        if ! { gemini --yolo --prompt "${PROMPT}" 2> >(tee "${TEMP_STDERR}" >&2) | tee "${TEMP_STDOUT}"; }; then 
           FAILED=true
         fi
 


### PR DESCRIPTION
Since #186, users wait until processes finish before seeing output. This uses tee with process substitution to stream live whilst maintaining separate stdout/stderr capture.

- Live output to console in real-time
- Stdout/stderr still captured separately
- Existing processing unchanged

Testing confirms both streaming and separation work correctly.