### PR TITLE
Add permissions needed to mint identity tokens

### DIFF
--- a/.github/workflows/gemini-dispatch.yml
+++ b/.github/workflows/gemini-dispatch.yml
@@ -110,6 +110,7 @@ jobs:
       contents: 'read'
       pull-requests: 'write'
       issues: 'write'
+      id-token: 'write'
     with:
       additional_context: '${{ needs.dispatch.outputs.additional_context }}'
     secrets: 'inherit'
@@ -123,6 +124,7 @@ jobs:
       contents: 'read'
       issues: 'write'
       pull-requests: 'write'
+      id-token: 'write'
     with:
       additional_context: '${{ needs.dispatch.outputs.additional_context }}'
     secrets: 'inherit'
@@ -136,6 +138,7 @@ jobs:
       contents: 'read'
       issues: 'write'
       pull-requests: 'write'
+      id-token: 'write'
     with:
       additional_context: '${{ needs.dispatch.outputs.additional_context }}'
     secrets: 'inherit'
@@ -153,6 +156,7 @@ jobs:
       contents: 'read'
       issues: 'write'
       pull-requests: 'write'
+      id-token: 'write'
     steps:
       - name: 'Mint identity token'
         id: 'mint_identity_token'


### PR DESCRIPTION
The workflows are failing because of missing permission. This change adds that permission.

Fixes https://github.com/google-github-actions/run-gemini-cli/issues/221

cc @sethvargo 
