### PR TITLE
feat: rename gemini-cli to gemini-invoke

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ to avoid this situation as org owner you can restrict who can approve the PR fol
 This type of action can be used to invoke a general-purpose, conversational Gemini
 AI assistant within the pull requests and issues to perform a wide range of
 tasks. For a detailed guide on how to set up the general-purpose Gemini CLI workflow,
-go to the [Gemini CLI workflow documentation](./examples/workflows/gemini-cli).
+go to the [Gemini Assistant workflow documentation](./examples/workflows/gemini-assistant).
 
 ### Inputs
 

--- a/examples/workflows/gemini-assistant/README.md
+++ b/examples/workflows/gemini-assistant/README.md
@@ -50,11 +50,11 @@ gha-creds-*.json
 
 To use this workflow, you can utilize either of the following methods:
 1. Run the `/setup-github` command in Gemini CLI on your terminal to set up workflows for your repository.
-2. Copy the `gemini-cli.yml` file into your repository's `.github/workflows` directory:
+2. Copy the `gemini-invoke.yml` file into your repository's `.github/workflows` directory:
 
 ```bash
 mkdir -p .github/workflows
-curl -o .github/workflows/gemini-cli.yml https://raw.githubusercontent.com/google-github-actions/run-gemini-cli/main/examples/workflows/gemini-cli/gemini-cli.yml
+curl -o .github/workflows/gemini-invoke.yml https://raw.githubusercontent.com/google-github-actions/run-gemini-cli/main/examples/workflows/gemini-assistant/gemini-invoke.yml
 ```
 
 ## Usage

--- a/examples/workflows/gemini-assistant/gemini-invoke.yml
+++ b/examples/workflows/gemini-assistant/gemini-invoke.yml
@@ -1,4 +1,4 @@
-name: '💬 Gemini CLI'
+name: '▶️ Gemini Invoke'
 
 on:
   pull_request_review_comment:


### PR DESCRIPTION
This commit renames the `gemini-cli` workflow to `gemini-invoke` to better reflect its purpose as a general-purpose invocation workflow.

The following changes are included:

- The `examples/workflows/gemini-cli` directory has been moved to `examples/workflows/gemini-invoke`.
- The `README.md` file has been updated to point to the new workflow documentation.
- The `gemini-cli.yml` workflow file has been renamed to `gemini-invoke.yml`.
