### PR TITLE
fix(workflow): ensure PR refs and JSON-safe env vars in gemini-review

### DIFF
--- a/.github/workflows/gemini-review.yml
+++ b/.github/workflows/gemini-review.yml
@@ -48,11 +48,11 @@ jobs:
         id: 'gemini_pr_review'
         env:
           GITHUB_TOKEN: '${{ steps.mint_identity_token.outputs.token || secrets.GITHUB_TOKEN || github.token }}'
-          ISSUE_TITLE: '${{ github.event.pull_request.title || github.event.issue.title }}'
-          ISSUE_BODY: '${{ github.event.pull_request.body || github.event.issue.body }}'
+          ISSUE_TITLE: '${{ toJSON(github.event.pull_request.title || github.event.issue.title) }}'
+          ISSUE_BODY: '${{ toJSON(github.event.pull_request.body || github.event.issue.body) }}'
           PULL_REQUEST_NUMBER: '${{ github.event.pull_request.number || github.event.issue.number }}'
           REPOSITORY: '${{ github.repository }}'
-          ADDITIONAL_CONTEXT: '${{ inputs.additional_context }}'
+          ADDITIONAL_CONTEXT: '${{ toJSON(inputs.additional_context) }}'
         with:
           gemini_cli_version: '${{ vars.GEMINI_CLI_VERSION }}'
           gcp_workload_identity_provider: '${{ vars.GCP_WIF_PROVIDER }}'

--- a/.github/workflows/gemini-review.yml
+++ b/.github/workflows/gemini-review.yml
@@ -40,6 +40,8 @@ jobs:
 
       - name: 'Checkout repository'
         uses: 'actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8' # ratchet:actions/checkout@v5
+        with:
+          ref: ${{ format('refs/pull/{0}/merge', github.event.pull_request.number || github.event.issue.number) }}
 
       - name: 'Run Gemini pull request review'
         uses: 'google-github-actions/run-gemini-cli@main' # ratchet:exclude


### PR DESCRIPTION



## Summary

This PR updates the **`gemini-review.yml`** workflow to correctly checkout PR refs and ensure that environment variables passed to Gemini are JSON-safe.

## Changes

* **Checkout step**

  * Explicitly set the `ref` to `refs/pull/{PR_NUMBER}/merge` to ensure the correct PR ref is used.
* **Environment variables**

  * Wrapped `ISSUE_TITLE`, `ISSUE_BODY`, and `ADDITIONAL_CONTEXT` in `toJSON(...)` to prevent YAML parsing issues and ensure proper string escaping.

## Rationale

* Without explicitly setting the PR ref, the workflow may fail to correctly fetch the PR changes.
* Using `toJSON` ensures values such as quotes, newlines, and special characters are safely passed to the Gemini CLI.

* The Issue Body should be moved to with: instead of env: because of the size limit. 

## Testing

* Verified workflow syntax locally with `act`.
* Confirmed that PR metadata (`title`, `body`, `additional_context`) is correctly serialized as JSON.

## Related Issues

N/A

