### PR TITLE
feat(docs): improve manual setup instructions for workflows

### DIFF
--- a/examples/workflows/gemini-assistant/README.md
+++ b/examples/workflows/gemini-assistant/README.md
@@ -8,6 +8,7 @@ In this guide you will learn how to use the Gemini CLI Assistant via GitHub Acti
   - [Setup](#setup)
     - [Prerequisites](#prerequisites)
     - [Setup Methods](#setup-methods)
+  - [Dependencies](#dependencies)
   - [Usage](#usage)
     - [Supported Triggers](#supported-triggers)
     - [How to Invoke the Gemini CLI Workflow](#how-to-invoke-the-gemini-cli-workflow)
@@ -57,6 +58,10 @@ mkdir -p .github/workflows
 curl -o .github/workflows/gemini-dispatch.yml https://raw.githubusercontent.com/google-github-actions/run-gemini-cli/main/examples/workflows/gemini-dispatch/gemini-dispatch.yml
 curl -o .github/workflows/gemini-invoke.yml https://raw.githubusercontent.com/google-github-actions/run-gemini-cli/main/examples/workflows/gemini-assistant/gemini-invoke.yml
 ```
+
+> **Note:** The `gemini-dispatch.yml` workflow is designed to call multiple
+> workflows. If you are only setting up `gemini-invoke.yml`, you should comment out or
+> remove the other jobs in your copy of `gemini-dispatch.yml`.
 
 ## Dependencies
 

--- a/examples/workflows/issue-triage/README.md
+++ b/examples/workflows/issue-triage/README.md
@@ -8,6 +8,7 @@ This document describes a comprehensive system for triaging GitHub issues using 
   - [Setup](#setup)
     - [Prerequisites](#prerequisites)
     - [Setup Methods](#setup-methods)
+  - [Dependencies](#dependencies)
   - [Usage](#usage)
     - [Supported Triggers](#supported-triggers)
     - [Real-Time Issue Triage](#real-time-issue-triage)
@@ -61,6 +62,10 @@ curl -o .github/workflows/gemini-dispatch.yml https://raw.githubusercontent.com/
 curl -o .github/workflows/gemini-triage.yml https://raw.githubusercontent.com/google-github-actions/run-gemini-cli/main/examples/workflows/issue-triage/gemini-triage.yml
 curl -o .github/workflows/gemini-scheduled-triage.yml https://raw.githubusercontent.com/google-github-actions/run-gemini-cli/main/examples/workflows/issue-triage/gemini-scheduled-triage.yml
 ```
+
+> **Note:** The `gemini-dispatch.yml` workflow is designed to call multiple
+> workflows. If you are only setting up `gemini-triage.yml`, you should comment out or
+> remove the other jobs in your copy of `gemini-dispatch.yml`.
 
 You can customize the prompts and settings in the workflow files to suit your specific needs. For example, you can change the triage logic, the labels that are applied, or the schedule of the scheduled triage.
 

--- a/examples/workflows/pr-review/README.md
+++ b/examples/workflows/pr-review/README.md
@@ -8,6 +8,7 @@ This document explains how to use the Gemini CLI on GitHub to automatically revi
   - [Setup](#setup)
     - [Prerequisites](#prerequisites)
     - [Setup Methods](#setup-methods)
+  - [Dependencies](#dependencies)
   - [Usage](#usage)
     - [Supported Triggers](#supported-triggers)
   - [Interaction Flow](#interaction-flow)
@@ -69,6 +70,10 @@ mkdir -p .github/workflows
 curl -o .github/workflows/gemini-dispatch.yml https://raw.githubusercontent.com/google-github-actions/run-gemini-cli/main/examples/workflows/gemini-dispatch/gemini-dispatch.yml
 curl -o .github/workflows/gemini-review.yml https://raw.githubusercontent.com/google-github-actions/run-gemini-cli/main/examples/workflows/pr-review/gemini-review.yml
 ```
+
+> **Note:** The `gemini-dispatch.yml` workflow is designed to call multiple
+> workflows. If you are only setting up `gemini-review.yml`, you should comment out or
+> remove the other jobs in your copy of `gemini-dispatch.yml`.
 
 ## Dependencies
 


### PR DESCRIPTION
The `gemini-dispatch.yml` workflow is designed to call other workflows like `gemini-review.yml`, `gemini-triage.yml`, and `gemini-invoke.yml`.

When a user manually sets up only one of these workflows (e.g., only for PR reviews), they might not have the other workflow files present in their repository. This can lead to errors when the dispatch workflow tries to call a non-existent workflow.

This change adds a note to the setup instructions for each of the main workflows (`pr-review`, `issue-triage`, `gemini-assistant`) advising users to comment out the unused jobs in their copy of `gemini-dispatch.yml`.

This prevents errors and makes the manual setup process more robust.

Fixes #256
