### PR TITLE
fix: enforce COMMENT event type for submit_pending_pull_request_review

### DIFF
--- a/.github/workflows/gemini-review.yml
+++ b/.github/workflows/gemini-review.yml
@@ -251,7 +251,7 @@ jobs:
                     {{SEVERITY}} {{COMMENT_TEXT}}
                     </COMMENT>
 
-            3. **Submit Final Review:** Call `mcp__github__submit_pending_pull_request_review` with a summary comment. **DO NOT** approve the pull request. **DO NOT** request changes. The summary comment **MUST** use this exact markdown format:
+            3. **Submit Final Review:** Call `mcp__github__submit_pending_pull_request_review` with a summary comment and event type "COMMENT". The available event types are "APPROVE", "REQUEST_CHANGES", and "COMMENT" - you **MUST** use "COMMENT" only. **DO NOT** use "APPROVE" or "REQUEST_CHANGES" event types. The summary comment **MUST** use this exact markdown format:
 
                 <SUMMARY>
                 ## 📋 Review Summary

--- a/examples/workflows/pr-review/gemini-review.yml
+++ b/examples/workflows/pr-review/gemini-review.yml
@@ -251,7 +251,7 @@ jobs:
                     {{SEVERITY}} {{COMMENT_TEXT}}
                     </COMMENT>
 
-            3. **Submit Final Review:** Call `mcp__github__submit_pending_pull_request_review` with a summary comment. **DO NOT** approve the pull request. **DO NOT** request changes. The summary comment **MUST** use this exact markdown format:
+            3. **Submit Final Review:** Call `mcp__github__submit_pending_pull_request_review` with a summary comment and event type "COMMENT". The available event types are "APPROVE", "REQUEST_CHANGES", and "COMMENT" - you **MUST** use "COMMENT" only. **DO NOT** use "APPROVE" or "REQUEST_CHANGES" event types. The summary comment **MUST** use this exact markdown format:
 
                 <SUMMARY>
                 ## 📋 Review Summary


### PR DESCRIPTION
- Explicitly specify event type 'COMMENT' for MCP tool submit_pending_pull_request_review
- Add clear instructions listing all available event types (APPROVE, REQUEST_CHANGES, COMMENT)
- Explicitly prohibit use of APPROVE and REQUEST_CHANGES event types
- Ensures bot only comments on PRs and never approves them automatically
- Note: Best practices already recommend branch protection rules and PR approval restrictions (see [docs/best-practices.md](https://github.com/google-github-actions/run-gemini-cli/blob/main/docs/best-practices.md))
