### PR TITLE
feat(workflows): add gemini_cli_version to all workflows

### DIFF
--- a/.github/workflows/gemini-invoke.yml
+++ b/.github/workflows/gemini-invoke.yml
@@ -50,6 +50,7 @@ jobs:
           REPOSITORY: '${{ github.repository }}'
           ADDITIONAL_CONTEXT: '${{ inputs.additional_context }}'
         with:
+          gemini_cli_version: '${{ vars.GEMINI_CLI_VERSION }}'
           gemini_api_key: '${{ secrets.GEMINI_API_KEY }}'
           gcp_workload_identity_provider: '${{ vars.GCP_WIF_PROVIDER }}'
           gcp_project_id: '${{ vars.GOOGLE_CLOUD_PROJECT }}'

--- a/.github/workflows/gemini-issue-fixer.yml
+++ b/.github/workflows/gemini-issue-fixer.yml
@@ -49,6 +49,7 @@ jobs:
           ISSUE_BODY: '${{ github.event.issue.body }}'
           BRANCH_NAME: 'gemini-fix-${{ github.event.issue.number }}'
         with:
+          gemini_cli_version: '${{ vars.GEMINI_CLI_VERSION }}'
           gemini_api_key: '${{ secrets.GEMINI_API_KEY }}'
           gcp_workload_identity_provider: '${{ vars.GCP_WIF_PROVIDER }}'
           gcp_project_id: '${{ vars.GOOGLE_CLOUD_PROJECT }}'

--- a/examples/workflows/gemini-assistant/gemini-invoke.yml
+++ b/examples/workflows/gemini-assistant/gemini-invoke.yml
@@ -50,6 +50,7 @@ jobs:
           REPOSITORY: '${{ github.repository }}'
           ADDITIONAL_CONTEXT: '${{ inputs.additional_context }}'
         with:
+          gemini_cli_version: '${{ vars.GEMINI_CLI_VERSION }}'
           gemini_api_key: '${{ secrets.GEMINI_API_KEY }}'
           gcp_workload_identity_provider: '${{ vars.GCP_WIF_PROVIDER }}'
           gcp_project_id: '${{ vars.GOOGLE_CLOUD_PROJECT }}'


### PR DESCRIPTION
This change adds the gemini_cli_version input to all workflows that use the google-github-actions/run-gemini-cli action.

This ensures that all workflows use the version of the Gemini CLI specified in the repository's variables, providing better version management and consistency across workflows.

Close https://github.com/google-github-actions/run-gemini-cli/issues/274