### PR TITLE
feat: clean up temp fix for empty API key

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -158,11 +158,6 @@ runs:
       run: |-
         set -euo pipefail
 
-        # Unset GEMINI_API_KEY if empty
-        if [ -z "${GEMINI_API_KEY}" ]; then
-          unset GEMINI_API_KEY
-        fi
-
         # Create a temporary directory for storing the output, and ensure it's
         # cleaned up later
         TEMP_STDOUT="$(mktemp -p "${RUNNER_TEMP}" gemini-out.XXXXXXXXXX)"


### PR DESCRIPTION
Previously, empty API keys caused errors so we handled this by unsetting the empty keys.

As of GenAI SDK version 1.16, this is handled correctly.

This change removes the temporary unsetting of the key.

Related: https://github.com/google-gemini/gemini-cli/pull/7377 

Fixes #248

