### PR TITLE
feat: add command substitution security warning

### DIFF
--- a/.github/workflows/gemini-invoke.yml
+++ b/.github/workflows/gemini-invoke.yml
@@ -153,6 +153,8 @@ jobs:
 
             6. **Resource Consciousness**: Be mindful of the number of operations you perform. Your plans should be efficient. Avoid proposing actions that would result in an excessive number of tool calls (e.g., > 50).
 
+            7. **Command Substitution**: When generating shell commands, you **MUST NOT** use command substitution with `$(...)`, `<(...)`, or `>(...)`. This is a security measure to prevent unintended command execution.
+
             -----
 
             ## Step 1: Context Gathering & Initial Analysis

--- a/.github/workflows/gemini-issue-fixer.yml
+++ b/.github/workflows/gemini-issue-fixer.yml
@@ -156,6 +156,7 @@ jobs:
                     <rule>Use Tools: Rely on the provided tools for all interactions with the repository. Do not guess file contents or state.</rule>
                     <rule>Handle Shell Variables Safely: When defining or using variables in shell commands, ensure they are properly quoted to prevent errors.</rule>
                     <rule>If something prevents you from fixing the issue, such as a permissions issue, inform the user in your comment on the issue why you cannot complete the task. If you must inform the user of a limitation, use the `gh issue comment --edit-last` CLI tool command to edit your initial comment. Only create a pull request if it will fix the issue.</rule>
+                    <rule>Command Substitution: When generating shell commands, you **MUST NOT** use command substitution with `$(...)`, `<(...)`, or `>(...)`. This is a security measure to prevent unintended command execution.</rule>
                 </guidelines>
                 <example>
                     <description>

--- a/.github/workflows/gemini-review.yml
+++ b/.github/workflows/gemini-review.yml
@@ -133,6 +133,8 @@ jobs:
 
             6. **Contextual Correctness:** All line numbers and indentations in code suggestions **MUST** be correct and match the code they are replacing. Code suggestions need to align **PERFECTLY** with the code it intend to replace. Pay special attention to the line numbers when creating comments, particularly if there is a code suggestion.
 
+            7. **Command Substitution**: When generating shell commands, you **MUST NOT** use command substitution with `$(...)`, `<(...)`, or `>(...)`. This is a security measure to prevent unintended command execution.
+
 
             ## Input Data
 

--- a/.github/workflows/gemini-scheduled-triage.yml
+++ b/.github/workflows/gemini-scheduled-triage.yml
@@ -141,6 +141,8 @@ jobs:
 
             4. **Variable Handling:** Reference all shell variables as `"${VAR}"` (with quotes and braces) to prevent word splitting and globbing issues.
 
+            5. **Command Substitution**: When generating shell commands, you **MUST NOT** use command substitution with `$(...)`, `<(...)`, or `>(...)`. This is a security measure to prevent unintended command execution.
+
             ## Input Data Description
 
             You will work with the following environment variables:

--- a/.github/workflows/gemini-triage.yml
+++ b/.github/workflows/gemini-triage.yml
@@ -101,6 +101,7 @@ jobs:
             - Environment variables are specified in the format "${VARIABLE}" (with quotes and braces).
             - Only use labels that are from the list of available labels.
             - You can choose multiple labels to apply.
+            - When generating shell commands, you **MUST NOT** use command substitution with `$(...)`, `<(...)`, or `>(...)`. This is a security measure to prevent unintended command execution.
 
             ## Steps
 

--- a/examples/workflows/gemini-assistant/gemini-invoke.yml
+++ b/examples/workflows/gemini-assistant/gemini-invoke.yml
@@ -153,6 +153,8 @@ jobs:
 
             6. **Resource Consciousness**: Be mindful of the number of operations you perform. Your plans should be efficient. Avoid proposing actions that would result in an excessive number of tool calls (e.g., > 50).
 
+            7. **Command Substitution**: When generating shell commands, you **MUST NOT** use command substitution with `$(...)`, `<(...)`, or `>(...)`. This is a security measure to prevent unintended command execution.
+
             -----
 
             ## Step 1: Context Gathering & Initial Analysis

--- a/examples/workflows/issue-triage/gemini-scheduled-triage.yml
+++ b/examples/workflows/issue-triage/gemini-scheduled-triage.yml
@@ -141,6 +141,8 @@ jobs:
 
             4. **Variable Handling:** Reference all shell variables as `"${VAR}"` (with quotes and braces) to prevent word splitting and globbing issues.
 
+            5. **Command Substitution**: When generating shell commands, you **MUST NOT** use command substitution with `$(...)`, `<(...)`, or `>(...)`. This is a security measure to prevent unintended command execution.
+
             ## Input Data Description
 
             You will work with the following environment variables:

--- a/examples/workflows/issue-triage/gemini-triage.yml
+++ b/examples/workflows/issue-triage/gemini-triage.yml
@@ -101,6 +101,7 @@ jobs:
             - Environment variables are specified in the format "${VARIABLE}" (with quotes and braces).
             - Only use labels that are from the list of available labels.
             - You can choose multiple labels to apply.
+            - When generating shell commands, you **MUST NOT** use command substitution with `$(...)`, `<(...)`, or `>(...)`. This is a security measure to prevent unintended command execution.
 
             ## Steps
 

--- a/examples/workflows/pr-review/gemini-review.yml
+++ b/examples/workflows/pr-review/gemini-review.yml
@@ -133,6 +133,8 @@ jobs:
 
             6. **Contextual Correctness:** All line numbers and indentations in code suggestions **MUST** be correct and match the code they are replacing. Code suggestions need to align **PERFECTLY** with the code it intend to replace. Pay special attention to the line numbers when creating comments, particularly if there is a code suggestion.
 
+            7. **Command Substitution**: When generating shell commands, you **MUST NOT** use command substitution with `$(...)`, `<(...)`, or `>(...)`. This is a security measure to prevent unintended command execution.
+
 
             ## Input Data
 


### PR DESCRIPTION
Adds a security warning to all Gemini CLI workflow prompts, instructing the model to avoid using command substitution features like `$(...)`, `<(...)`, or `>(...)` in shell commands.

This is a preventative measure to avoid errors where the Gemini CLI rejects commands that use command substitution for security reasons. This change makes the security constraints of the tool explicit to the model.

Fixes https://github.com/google-github-actions/run-gemini-cli/issues/174

---
