### PR TITLE
fix(action): correct quoting in workflow expressions

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -84,11 +84,11 @@ runs:
       shell: 'bash'
       run: '${{ github.action_path }}/scripts/validate-inputs.sh'
       env:
-        INPUT_GEMINI_API_KEY_PRESENT: '${{ inputs.gemini_api_key != '' }}'
-        INPUT_GOOGLE_API_KEY_PRESENT: '${{ inputs.google_api_key != '' }}'
-        INPUT_GCP_WORKLOAD_IDENTITY_PROVIDER_PRESENT: '${{ inputs.gcp_workload_identity_provider != '' }}'
-        INPUT_GCP_PROJECT_ID_PRESENT: '${{ inputs.gcp_project_id != '' }}'
-        INPUT_GCP_SERVICE_ACCOUNT_PRESENT: '${{ inputs.gcp_service_account != '' }}'
+        INPUT_GEMINI_API_KEY_PRESENT: "${{ inputs.gemini_api_key != '' }}"
+        INPUT_GOOGLE_API_KEY_PRESENT: "${{ inputs.google_api_key != '' }}"
+        INPUT_GCP_WORKLOAD_IDENTITY_PROVIDER_PRESENT: "${{ inputs.gcp_workload_identity_provider != '' }}"
+        INPUT_GCP_PROJECT_ID_PRESENT: "${{ inputs.gcp_project_id != '' }}"
+        INPUT_GCP_SERVICE_ACCOUNT_PRESENT: "${{ inputs.gcp_service_account != '' }}"
         INPUT_USE_VERTEX_AI: '${{ inputs.use_vertex_ai }}'
         INPUT_USE_GEMINI_CODE_ASSIST: '${{ inputs.use_gemini_code_assist }}'
     - name: 'Configure Gemini CLI'


### PR DESCRIPTION
Corrects the quoting of GitHub Actions expressions in `action.yml`. The expression parser was failing when an expression contained single quotes while also being wrapped in single quotes.

This change switches to using double quotes to wrap expressions that contain single quotes, which resolves the parsing error and ensures the workflow functions correctly.

<!--
Thank you for proposing a pull request! Please note that SOME TESTS WILL
LIKELY FAIL due to how GitHub exposes secrets in Pull Requests from forks.
Someone from the team will review your Pull Request and respond.

Please describe your change and any implementation details below.
-->
