### PR TITLE
feat(validate-inputs): downgrade validation failures to warnings (#300)

### DIFF
--- a/scripts/validate-inputs.sh
+++ b/scripts/validate-inputs.sh
@@ -1,22 +1,21 @@
 #!/bin/bash
 set -euo pipefail
 
-# Emit a clear error in three places:
+# Emit a clear warning in three places without failing the step:
 # - STDERR (visible in step logs)
-# - GitHub annotation with a title (more visible in Checks)
-# - Step summary (always shown in the job summary)
-error() {
+# - GitHub warning annotation with a title (visible in Checks)
+# - Step summary (shown in the job summary)
+warn() {
   local msg="$1"
-  echo "ERROR: ${msg}" >&2
-  echo "::error title=Input validation failed::${msg}"
+  echo "WARNING: ${msg}" >&2
+  echo "::warning title=Input validation::${msg}"
   if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
     {
-      echo "### Input validation failed"
+      echo "### Input validation warnings"
       echo
       echo "- ${msg}"
     } >> "${GITHUB_STEP_SUMMARY}"
   fi
-  exit 1
 }
 
 # Auth inputs (as boolean presence flags)
@@ -37,39 +36,39 @@ if [[ "${google_api_key_present}" == "true" ]]; then ((auth_methods++)); fi
 if [[ "${gcp_workload_identity_provider_present}" == "true" ]]; then ((auth_methods++)); fi
 
 if [[ ${auth_methods} -eq 0 ]]; then
-  error "No authentication method provided. Please provide one of 'gemini_api_key', 'google_api_key', or 'gcp_workload_identity_provider'."
+  warn "No authentication method provided. Please provide one of 'gemini_api_key', 'google_api_key', or 'gcp_workload_identity_provider'."
 fi
 
 if [[ ${auth_methods} -gt 1 ]]; then
-  error "Multiple authentication methods provided. Please use only one of 'gemini_api_key', 'google_api_key', or 'gcp_workload_identity_provider'."
+  warn "Multiple authentication methods provided. Please use only one of 'gemini_api_key', 'google_api_key', or 'gcp_workload_identity_provider'."
 fi
 
 # WIF validation
 if [[ "${gcp_workload_identity_provider_present}" == "true" ]]; then
   if [[ "${gcp_project_id_present}" != "true" || "${gcp_service_account_present}" != "true" ]]; then
-    error "When using Workload Identity Federation ('gcp_workload_identity_provider'), you must also provide 'gcp_project_id' and 'gcp_service_account'."
+    warn "When using Workload Identity Federation ('gcp_workload_identity_provider'), you must also provide 'gcp_project_id' and 'gcp_service_account'."
   fi
   if [[ "${use_vertex_ai}" != "true" && "${use_gemini_code_assist}" != "true" ]]; then
-    error "When using Workload Identity Federation, you must set either 'use_vertex_ai' or 'use_gemini_code_assist' to 'true'. Both are set to 'false', please choose one."
+    warn "When using Workload Identity Federation, you must set either 'use_vertex_ai' or 'use_gemini_code_assist' to 'true'. Both are set to 'false', please choose one."
   fi
   if [[ "${use_vertex_ai}" == "true" && "${use_gemini_code_assist}" == "true" ]]; then
-    error "When using Workload Identity Federation, 'use_vertex_ai' and 'use_gemini_code_assist' cannot both be 'true'. Both are set to 'true', please choose one."
+    warn "When using Workload Identity Federation, 'use_vertex_ai' and 'use_gemini_code_assist' cannot both be 'true'. Both are set to 'true', please choose one."
   fi
 fi
 
 # Vertex AI API Key validation
 if [[ "${google_api_key_present}" == "true" ]]; then
   if [[ "${use_vertex_ai}" != "true" ]]; then
-    error "When using 'google_api_key', you must set 'use_vertex_ai' to 'true'."
+    warn "When using 'google_api_key', you must set 'use_vertex_ai' to 'true'."
   fi
   if [[ "${use_gemini_code_assist}" == "true" ]]; then
-    error "When using 'google_api_key', 'use_gemini_code_assist' cannot be 'true'."
+    warn "When using 'google_api_key', 'use_gemini_code_assist' cannot be 'true'."
   fi
 fi
 
 # Gemini API Key validation
 if [[ "${gemini_api_key_present}" == "true" ]]; then
   if [[ "${use_vertex_ai}" == "true" || "${use_gemini_code_assist}" == "true" ]]; then
-    error "When using 'gemini_api_key', both 'use_vertex_ai' and 'use_gemini_code_assist' must be 'false'."
+    warn "When using 'gemini_api_key', both 'use_vertex_ai' and 'use_gemini_code_assist' must be 'false'."
   fi
 fi


### PR DESCRIPTION
Emit ::warning annotations, log to stderr, and append to step summary without failing the step. Replace error exits with warnings across all validation branches.

We can move this to errors in future releases, but don't want to break downstream users once we cut a release.

<!--
Thank you for proposing a pull request! Please note that SOME TESTS WILL
LIKELY FAIL due to how GitHub exposes secrets in Pull Requests from forks.
Someone from the team will review your Pull Request and respond.

Please describe your change and any implementation details below.
-->
