### PR TITLE
fix(action): correct input validation script behavior

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -84,7 +84,7 @@ runs:
       id: 'validate_inputs'
       shell: 'bash'
       run: |-
-        set -euo pipefail
+        set -exuo pipefail
 
         # Emit a clear warning in three places without failing the step
         warn() {
@@ -102,9 +102,9 @@ runs:
 
         # Validate the count of authentication methods
         auth_methods=0
-        if [[ "${INPUT_GEMINI_API_KEY_PRESENT:-false}" == "true" ]]; then ((auth_methods++)); fi
-        if [[ "${INPUT_GOOGLE_API_KEY_PRESENT:-false}" == "true" ]]; then ((auth_methods++)); fi
-        if [[ "${INPUT_GCP_WORKLOAD_IDENTITY_PROVIDER_PRESENT:-false}" == "true" ]]; then ((auth_methods++)); fi
+        if [[ "${INPUT_GEMINI_API_KEY_PRESENT:-false}" == "true" ]]; then ((++auth_methods)); fi
+        if [[ "${INPUT_GOOGLE_API_KEY_PRESENT:-false}" == "true" ]]; then ((++auth_methods)); fi
+        if [[ "${INPUT_GCP_WORKLOAD_IDENTITY_PROVIDER_PRESENT:-false}" == "true" ]]; then ((++auth_methods)); fi
 
         if [[ ${auth_methods} -eq 0 ]]; then
           warn "No authentication method provided. Please provide one of 'gemini_api_key', 'google_api_key', or 'gcp_workload_identity_provider'."


### PR DESCRIPTION
The input validation script was failing silently and incorrectly when exactly one authentication method was provided. This was due to the interaction between 'set -e' and the exit code of Bash arithmetic evaluation.

The post-increment expression 'auth_methods++' evaluates to 0 when auth_methods is 0. In Bash, an arithmetic expression that evaluates to 0 returns an exit code of 1. With 'set -e' enabled, this non-zero exit code caused the script to exit as if an error had occurred.

This commit changes the post-increment to a pre-increment '++auth_methods'. This ensures the expression always evaluates to a non-zero value (1, 2, or 3), resulting in a 0 exit code and preventing the script from failing.

Additionally, the '-x' flag has been added to the 'set' command to enable xtrace, which will print commands as they are executed. This improves the debuggability of the script.
