### PR TITLE
fix(triage): correct duplicate step numbering in workflow

### DIFF
--- a/.github/workflows/gemini-triage.yml
+++ b/.github/workflows/gemini-triage.yml
@@ -115,11 +115,11 @@ jobs:
 
             5. Based on the issue title and issue body, classify the issue and choose all appropriate labels from the list of available labels.
 
-            5. Classify the issue by identifying the appropriate labels from the list of available labels.
+            6. Classify the issue by identifying the appropriate labels from the list of available labels.
 
-            6. Convert the list of appropriate labels into a comma-separated list (CSV). If there are no appropriate labels, use the empty string.
+            7. Convert the list of appropriate labels into a comma-separated list (CSV). If there are no appropriate labels, use the empty string.
 
-            7. Use the "echo" shell command to append the CSV labels into the filepath referenced by the environment variable "${GITHUB_ENV}":
+            8. Use the "echo" shell command to append the CSV labels into the filepath referenced by the environment variable "${GITHUB_ENV}":
 
                 ```
                 echo "SELECTED_LABELS=[APPROPRIATE_LABELS_AS_CSV]" >> "[filepath_for_env]"


### PR DESCRIPTION
The `gemini-triage.yml` workflow had a duplicate step number, which caused confusion when reading the workflow. This commit corrects the numbering to be sequential.