### PR TITLE
refactor(workflows): improve prompts to use env vars directly

### DIFF
--- a/.github/workflows/gemini-invoke.yml
+++ b/.github/workflows/gemini-invoke.yml
@@ -161,7 +161,14 @@ jobs:
 
             Begin every task by building a complete picture of the situation.
 
-            1. **Load Initial Variables**: Load `${TITLE}`, `${DESCRIPTION}`, `${EVENT_NAME}`, etc.
+            1. **Initial Context**:
+               - **Title**: ${{ env.TITLE }}
+               - **Description**: ${{ env.DESCRIPTION }}
+               - **Event Name**: ${{ env.EVENT_NAME }}
+               - **Is Pull Request**: ${{ env.IS_PULL_REQUEST }}
+               - **Issue/PR Number**: ${{ env.ISSUE_NUMBER }}
+               - **Repository**: ${{ env.REPOSITORY }}
+               - **Additional Context/Request**: ${{ env.ADDITIONAL_CONTEXT }}
 
             2. **Deepen Context with Tools**: Use `mcp__github__get_issue`, `mcp__github__get_pull_request_diff`, and `mcp__github__get_file_contents` to investigate the request thoroughly.
 

--- a/.github/workflows/gemini-issue-fixer.yml
+++ b/.github/workflows/gemini-issue-fixer.yml
@@ -102,17 +102,14 @@ jobs:
                         <issue>
                             <repository>${{ env.REPOSITORY }}</repository>
                             <number>${{ env.ISSUE_NUMBER }}</number>
-                            <title>The title exists in the ISSUE_TITLE environment variable. Run `echo $ISSUE_TITLE` to fetch it.</title>
-                            <body>The title exists in the ISSUE_BODY environment variable. Run `echo $ISSUE_BODY` to fetch it.</body>
+                            <title>${{ env.ISSUE_TITLE }}</title>
+                            <body>${{ env.ISSUE_BODY }}</body>
                         </issue>
                     </github_event>
                 </context>
                 <instructions>
                     <description>Follow these steps sequentially to resolve the issue.</description>
                     <steps>
-                        <step id="0" name="Get Issue Title and Issue Body">
-                            The issue's title and body are stored in the ISSUE_TITLE and ISSUE_BODY environment variables. Read them with `echo $ISSUE_TITLE` and `echo $ISSUE_BODY`.
-                        </step>
                         <step id="1" name="Understand Project Standards">
                             The initial context provided to you includes a file tree. If you see a `GEMINI.md` or `CONTRIBUTING.md` file, use the GitHub MCP `get_file_contents` tool to read it first. This file may contain critical project-specific instructions, such as commands for building, testing, or linting.
                         </step>

--- a/.github/workflows/gemini-review.yml
+++ b/.github/workflows/gemini-review.yml
@@ -138,9 +138,9 @@ jobs:
 
             ## Input Data
 
-            - Retrieve the GitHub repository name from the environment variable "${REPOSITORY}".
-            - Retrieve the GitHub pull request number from the environment variable "${PULL_REQUEST_NUMBER}".
-            - Retrieve the additional user instructions and context from the environment variable "${ADDITIONAL_CONTEXT}".
+            - **GitHub Repository**: ${{ env.REPOSITORY }}
+            - **Pull Request Number**: ${{ env.PULL_REQUEST_NUMBER }}
+            - **Additional User Instructions**: ${{ env.ADDITIONAL_CONTEXT }}
             - Use `mcp__github__get_pull_request` to get the title, body, and metadata about the pull request.
             - Use `mcp__github__get_pull_request_files` to get the list of files that were added, removed, and changed in the pull request.
             - Use `mcp__github__get_pull_request_diff` to get the diff from the pull request. The diff includes code versions with line numbers for the before (LEFT) and after (RIGHT) code snippets for each diff.

--- a/.github/workflows/gemini-scheduled-triage.yml
+++ b/.github/workflows/gemini-scheduled-triage.yml
@@ -143,33 +143,37 @@ jobs:
 
             5. **Command Substitution**: When generating shell commands, you **MUST NOT** use command substitution with `$(...)`, `<(...)`, or `>(...)`. This is a security measure to prevent unintended command execution.
 
-            ## Input Data Description
+            ## Input Data
 
-            You will work with the following environment variables:
+            The following data is provided for your analysis:
 
-                - **`AVAILABLE_LABELS`**: Contains a single, comma-separated string of all available label names (e.g., `"kind/bug,priority/p1,docs"`).
+            **Available Labels** (single, comma-separated string of all available label names):
+            ```
+            ${{ env.AVAILABLE_LABELS }}
+            ```
 
-                - **`ISSUES_TO_TRIAGE`**: Contains a string of a JSON array, where each object has `"number"`, `"title"`, and `"body"` keys.
+            **Issues to Triage** (JSON array where each object has `"number"`, `"title"`, and `"body"` keys):
+            ```
+            ${{ env.ISSUES_TO_TRIAGE }}
+            ```
 
-                - **`GITHUB_ENV`**: Contains the file path where your final JSON output must be written.
+            **Output File Path** where your final JSON output must be written:
+            ```
+            ${{ env.GITHUB_ENV }}
+            ```
 
             ## Execution Workflow
 
-            Follow this five-step process sequentially.
+            Follow this four-step process sequentially:
 
-            ## Step 1: Retrieve Input Data
+            ## Step 1: Parse Input Data
 
-            First, retrieve all necessary information from the environment by executing the following shell commands. You will use the resulting shell variables in the subsequent steps.
+            Parse the provided data above:
+            - Split the available labels by comma to get the list of valid labels
+            - Parse the JSON array of issues to analyze
+            - Note the output file path where you will write your results
 
-            1. `Run: LABELS_DATA=$(echo "${AVAILABLE_LABELS}")`
-            2. `Run: ISSUES_DATA=$(echo "${ISSUES_TO_TRIAGE}")`
-            3. `Run: OUTPUT_PATH=$(echo "${GITHUB_ENV}")`
-
-            ## Step 2: Parse Inputs
-
-            Parse the content of the `LABELS_DATA` shell variable into a list of strings. Parse the content of the `ISSUES_DATA` shell variable into a JSON array of issue objects.
-
-            ## Step 3: Analyze Label Semantics
+            ## Step 2: Analyze Label Semantics
 
             Before reviewing the issues, create an internal map of the semantic purpose of each available label based on its name. For example:
 
@@ -183,7 +187,7 @@ jobs:
 
             This semantic map will serve as your classification criteria.
 
-            ## Step 4: Triage Issues
+            ## Step 3: Triage Issues
 
             Iterate through each issue object you parsed in Step 2. For each issue:
 
@@ -195,11 +199,11 @@ jobs:
 
             4. If no available labels are a clear and confident match for an issue, exclude that issue from the final output.
 
-            ## Step 5: Construct and Write Output
+            ## Step 4: Construct and Write Output
 
             Assemble the results into a single JSON array, formatted as a string, according to the **Output Specification** below. Finally, execute the command to write this string to the output file, ensuring the JSON is enclosed in single quotes to prevent shell interpretation.
 
-                - `Run: echo 'TRIAGED_ISSUES=...' > "${OUTPUT_PATH}"`. (Replace `...` with the final, minified JSON array string).
+                - Use the shell command to write: `echo 'TRIAGED_ISSUES=...' > "$GITHUB_ENV"` (Replace `...` with the final, minified JSON array string).
 
             ## Output Specification
 

--- a/.github/workflows/gemini-triage.yml
+++ b/.github/workflows/gemini-triage.yml
@@ -97,29 +97,41 @@ jobs:
 
             ## Guidelines
 
-            - Retrieve the value for environment variables using the "echo" shell command.
-            - Environment variables are specified in the format "${VARIABLE}" (with quotes and braces).
             - Only use labels that are from the list of available labels.
             - You can choose multiple labels to apply.
             - When generating shell commands, you **MUST NOT** use command substitution with `$(...)`, `<(...)`, or `>(...)`. This is a security measure to prevent unintended command execution.
 
+            ## Input Data
+
+            **Available Labels** (comma-separated):
+            ```
+            ${{ env.AVAILABLE_LABELS }}
+            ```
+
+            **Issue Title**:
+            ```
+            ${{ env.ISSUE_TITLE }}
+            ```
+
+            **Issue Body**:
+            ```
+            ${{ env.ISSUE_BODY }}
+            ```
+
+            **Output File Path**:
+            ```
+            ${{ env.GITHUB_ENV }}
+            ```
+
             ## Steps
 
-            1. Retrieve the available labels from the environment variable: "${AVAILABLE_LABELS}".
+            1. Review the issue title, issue body, and available labels provided above.
 
-            2. Retrieve the issue title from the environment variable: "${ISSUE_TITLE}".
+            2. Based on the issue title and issue body, classify the issue and choose all appropriate labels from the list of available labels.
 
-            3. Retrieve the issue body from the environment variable: "${ISSUE_BODY}".
+            3. Convert the list of appropriate labels into a comma-separated list (CSV). If there are no appropriate labels, use the empty string.
 
-            4. Review the issue title, issue body, and available labels.
-
-            5. Based on the issue title and issue body, classify the issue and choose all appropriate labels from the list of available labels.
-
-            6. Classify the issue by identifying the appropriate labels from the list of available labels.
-
-            7. Convert the list of appropriate labels into a comma-separated list (CSV). If there are no appropriate labels, use the empty string.
-
-            8. Use the "echo" shell command to append the CSV labels into the filepath referenced by the environment variable "${GITHUB_ENV}":
+            4. Use the "echo" shell command to append the CSV labels to the output file path provided above:
 
                 ```
                 echo "SELECTED_LABELS=[APPROPRIATE_LABELS_AS_CSV]" >> "[filepath_for_env]"

--- a/examples/workflows/gemini-assistant/gemini-invoke.yml
+++ b/examples/workflows/gemini-assistant/gemini-invoke.yml
@@ -161,7 +161,14 @@ jobs:
 
             Begin every task by building a complete picture of the situation.
 
-            1. **Load Initial Variables**: Load `${TITLE}`, `${DESCRIPTION}`, `${EVENT_NAME}`, etc.
+            1. **Initial Context**:
+               - **Title**: ${{ env.TITLE }}
+               - **Description**: ${{ env.DESCRIPTION }}
+               - **Event Name**: ${{ env.EVENT_NAME }}
+               - **Is Pull Request**: ${{ env.IS_PULL_REQUEST }}
+               - **Issue/PR Number**: ${{ env.ISSUE_NUMBER }}
+               - **Repository**: ${{ env.REPOSITORY }}
+               - **Additional Context/Request**: ${{ env.ADDITIONAL_CONTEXT }}
 
             2. **Deepen Context with Tools**: Use `mcp__github__get_issue`, `mcp__github__get_pull_request_diff`, and `mcp__github__get_file_contents` to investigate the request thoroughly.
 

--- a/examples/workflows/issue-triage/gemini-scheduled-triage.yml
+++ b/examples/workflows/issue-triage/gemini-scheduled-triage.yml
@@ -143,33 +143,37 @@ jobs:
 
             5. **Command Substitution**: When generating shell commands, you **MUST NOT** use command substitution with `$(...)`, `<(...)`, or `>(...)`. This is a security measure to prevent unintended command execution.
 
-            ## Input Data Description
+            ## Input Data
 
-            You will work with the following environment variables:
+            The following data is provided for your analysis:
 
-                - **`AVAILABLE_LABELS`**: Contains a single, comma-separated string of all available label names (e.g., `"kind/bug,priority/p1,docs"`).
+            **Available Labels** (single, comma-separated string of all available label names):
+            ```
+            ${{ env.AVAILABLE_LABELS }}
+            ```
 
-                - **`ISSUES_TO_TRIAGE`**: Contains a string of a JSON array, where each object has `"number"`, `"title"`, and `"body"` keys.
+            **Issues to Triage** (JSON array where each object has `"number"`, `"title"`, and `"body"` keys):
+            ```
+            ${{ env.ISSUES_TO_TRIAGE }}
+            ```
 
-                - **`GITHUB_ENV`**: Contains the file path where your final JSON output must be written.
+            **Output File Path** where your final JSON output must be written:
+            ```
+            ${{ env.GITHUB_ENV }}
+            ```
 
             ## Execution Workflow
 
-            Follow this five-step process sequentially.
+            Follow this four-step process sequentially:
 
-            ## Step 1: Retrieve Input Data
+            ## Step 1: Parse Input Data
 
-            First, retrieve all necessary information from the environment by executing the following shell commands. You will use the resulting shell variables in the subsequent steps.
+            Parse the provided data above:
+            - Split the available labels by comma to get the list of valid labels
+            - Parse the JSON array of issues to analyze
+            - Note the output file path where you will write your results
 
-            1. `Run: LABELS_DATA=$(echo "${AVAILABLE_LABELS}")`
-            2. `Run: ISSUES_DATA=$(echo "${ISSUES_TO_TRIAGE}")`
-            3. `Run: OUTPUT_PATH=$(echo "${GITHUB_ENV}")`
-
-            ## Step 2: Parse Inputs
-
-            Parse the content of the `LABELS_DATA` shell variable into a list of strings. Parse the content of the `ISSUES_DATA` shell variable into a JSON array of issue objects.
-
-            ## Step 3: Analyze Label Semantics
+            ## Step 2: Analyze Label Semantics
 
             Before reviewing the issues, create an internal map of the semantic purpose of each available label based on its name. For example:
 
@@ -183,7 +187,7 @@ jobs:
 
             This semantic map will serve as your classification criteria.
 
-            ## Step 4: Triage Issues
+            ## Step 3: Triage Issues
 
             Iterate through each issue object you parsed in Step 2. For each issue:
 
@@ -195,11 +199,11 @@ jobs:
 
             4. If no available labels are a clear and confident match for an issue, exclude that issue from the final output.
 
-            ## Step 5: Construct and Write Output
+            ## Step 4: Construct and Write Output
 
             Assemble the results into a single JSON array, formatted as a string, according to the **Output Specification** below. Finally, execute the command to write this string to the output file, ensuring the JSON is enclosed in single quotes to prevent shell interpretation.
 
-                - `Run: echo 'TRIAGED_ISSUES=...' > "${OUTPUT_PATH}"`. (Replace `...` with the final, minified JSON array string).
+                - Use the shell command to write: `echo 'TRIAGED_ISSUES=...' > "$GITHUB_ENV"` (Replace `...` with the final, minified JSON array string).
 
             ## Output Specification
 

--- a/examples/workflows/issue-triage/gemini-triage.yml
+++ b/examples/workflows/issue-triage/gemini-triage.yml
@@ -97,29 +97,41 @@ jobs:
 
             ## Guidelines
 
-            - Retrieve the value for environment variables using the "echo" shell command.
-            - Environment variables are specified in the format "${VARIABLE}" (with quotes and braces).
             - Only use labels that are from the list of available labels.
             - You can choose multiple labels to apply.
             - When generating shell commands, you **MUST NOT** use command substitution with `$(...)`, `<(...)`, or `>(...)`. This is a security measure to prevent unintended command execution.
 
+            ## Input Data
+
+            **Available Labels** (comma-separated):
+            ```
+            ${{ env.AVAILABLE_LABELS }}
+            ```
+
+            **Issue Title**:
+            ```
+            ${{ env.ISSUE_TITLE }}
+            ```
+
+            **Issue Body**:
+            ```
+            ${{ env.ISSUE_BODY }}
+            ```
+
+            **Output File Path**:
+            ```
+            ${{ env.GITHUB_ENV }}
+            ```
+
             ## Steps
 
-            1. Retrieve the available labels from the environment variable: "${AVAILABLE_LABELS}".
+            1. Review the issue title, issue body, and available labels provided above.
 
-            2. Retrieve the issue title from the environment variable: "${ISSUE_TITLE}".
+            2. Based on the issue title and issue body, classify the issue and choose all appropriate labels from the list of available labels.
 
-            3. Retrieve the issue body from the environment variable: "${ISSUE_BODY}".
+            3. Convert the list of appropriate labels into a comma-separated list (CSV). If there are no appropriate labels, use the empty string.
 
-            4. Review the issue title, issue body, and available labels.
-
-            5. Based on the issue title and issue body, classify the issue and choose all appropriate labels from the list of available labels.
-
-            6. Classify the issue by identifying the appropriate labels from the list of available labels.
-
-            7. Convert the list of appropriate labels into a comma-separated list (CSV). If there are no appropriate labels, use the empty string.
-
-            8. Use the "echo" shell command to append the CSV labels into the filepath referenced by the environment variable "${GITHUB_ENV}":
+            4. Use the "echo" shell command to append the CSV labels to the output file path provided above:
 
                 ```
                 echo "SELECTED_LABELS=[APPROPRIATE_LABELS_AS_CSV]" >> "[filepath_for_env]"

--- a/examples/workflows/pr-review/gemini-review.yml
+++ b/examples/workflows/pr-review/gemini-review.yml
@@ -138,9 +138,9 @@ jobs:
 
             ## Input Data
 
-            - Retrieve the GitHub repository name from the environment variable "${REPOSITORY}".
-            - Retrieve the GitHub pull request number from the environment variable "${PULL_REQUEST_NUMBER}".
-            - Retrieve the additional user instructions and context from the environment variable "${ADDITIONAL_CONTEXT}".
+            - **GitHub Repository**: ${{ env.REPOSITORY }}
+            - **Pull Request Number**: ${{ env.PULL_REQUEST_NUMBER }}
+            - **Additional User Instructions**: ${{ env.ADDITIONAL_CONTEXT }}
             - Use `mcp__github__get_pull_request` to get the title, body, and metadata about the pull request.
             - Use `mcp__github__get_pull_request_files` to get the list of files that were added, removed, and changed in the pull request.
             - Use `mcp__github__get_pull_request_diff` to get the diff from the pull request. The diff includes code versions with line numbers for the before (LEFT) and after (RIGHT) code snippets for each diff.


### PR DESCRIPTION
The prompts in the workflows are updated to directly embed environment variables using `${{ env.VAR }}` syntax.

This makes the prompts clearer and avoids instructing the model to use `echo` to retrieve values, simplifying the instructions.

This should also improve quality of response.

cc @anj-s 