### PR TITLE
fix(review): Remove --source argument to match CLI 8.0 release

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -230,7 +230,7 @@ runs:
             extension=$(echo "${extension}" | xargs)
             if [[ -n "${extension}" ]]; then
               echo "Installing ${extension}..."
-              echo "Y" | gemini extensions install --source "${extension}"
+              echo "Y" | gemini extensions install "${extension}"
             fi
           done
         fi


### PR DESCRIPTION
Gemini CLI 8.0 release introduced [PR#10628](https://github.com/google-gemini/gemini-cli/pull/10628) which removes the need for a path/source argument when installing extensions and breaks run-gemini-cli's extension installation.

Removing `--source` and relying on positional arguments patches `run-gemini-cli` for Gemini CLI 8.0+

I've tested this locally as well in https://github.com/CallumHYoung/testrepo/pull/3 which relies on https://github.com/CallumHYoung/run-gemini-cli