### PR TITLE
fix(action): Uploading artifacts is optional

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -299,8 +299,7 @@ runs:
         GEMINI_MODEL: '${{ inputs.gemini_model }}'
 
     - name: 'Upload Gemini CLI outputs'
-      if: |-
-        ${{ inputs.upload_artifacts }}
+      if: inputs.upload_artifacts == 'true'
       uses: 'actions/upload-artifact@v4' # ratchet:exclude
       with:
         name: 'gemini-output'


### PR DESCRIPTION
The check for 'upload_artifacts' is not toggleable as intended, this change adds comparing the string against 'true' for it to upload

Tests (Pay attention to the upload_artifacts input, as well as the repository location of the action:
---

Testing trying to toggle off artifact uploading (**it still uploads**): https://github.com/CallumHYoung/security/actions/runs/18741295611/workflow

Setting the repository variable UPLOAD_ARTIFACTS as false: (**still uploads**):
https://github.com/CallumHYoung/security/actions/runs/18741421117/job/53458444124

---
Tested without the input (**no longer uploads**): https://github.com/CallumHYoung/security/actions/runs/18741087822/workflow
Tested with `vars.UPLOAD_ARTIFACTS` passed from the workflow but not set (**no longer uploads**): https://github.com/CallumHYoung/security/actions/runs/18740724625/workflow
Tested with upload_artifacts set to 'true' (**uploads**): https://github.com/CallumHYoung/security/actions/runs/18740858893/workflow
Tested with upload_artifacts set to 'false' (**no longer uploads**): https://github.com/CallumHYoung/security/actions/runs/18740427308/workflow

I've also tested this with setting the repository variable to false/true and it also works (this example is set to true and it uploads artifacts):
https://github.com/CallumHYoung/security/actions/runs/18741524575/job/53458772968