### PR TITLE
fix(action): correct upload artifacts condition

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -72,7 +72,7 @@ inputs:
     description: 'A list of Gemini CLI extensions to install.'
     required: false
   upload_artifacts:
-    description: 'Whether or not to upload artifacts to the github action.'
+    description: 'Whether to upload artifacts to the github action.'
     required: false
     default: 'false'
 
@@ -300,7 +300,7 @@ runs:
 
     - name: 'Upload Gemini CLI outputs'
       if: |-
-        ${{ inputs.upload_artifacts }}
+        ${{ inputs.upload_artifacts == 'true' }}
       uses: 'actions/upload-artifact@v4' # ratchet:exclude
       with:
         name: 'gemini-output'


### PR DESCRIPTION
The previous condition `${{ inputs.upload_artifacts }}` would evaluate to true for any non-empty string, causing artifacts to be uploaded even when the input was false.

This change corrects the condition to `${{ inputs.upload_artifacts == true }}`, ensuring that artifacts are only uploaded when the `upload_artifacts` input is explicitly set to true.

Co-authored-by: calyoung@google.com
