### PR TITLE
feat: support direct wif

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,10 @@ go to the [Gemini Assistant workflow documentation](./examples/workflows/gemini-
 
 -   <a name="__input_gcp_workload_identity_provider"></a><a href="#user-content-__input_gcp_workload_identity_provider"><code>gcp_workload_identity_provider</code></a>: _(Optional)_ The Google Cloud Workload Identity Provider.
 
+-   <a name="__input_gcp_token_format"></a><a href="#user-content-__input_gcp_token_format"><code>gcp_token_format</code></a>: _(Optional, default: `access_token`)_ The token format for authentication. Set to "access_token" to generate access tokens (requires service account), or set to empty string for direct WIF. Can be "access_token" or "id_token".
+
+-   <a name="__input_gcp_access_token_scopes"></a><a href="#user-content-__input_gcp_access_token_scopes"><code>gcp_access_token_scopes</code></a>: _(Optional, default: `https://www.googleapis.com/auth/cloud-platform,https://www.googleapis.com/auth/userinfo.email,https://www.googleapis.com/auth/userinfo.profile`)_ The access token scopes when using token_format "access_token". Comma-separated list of OAuth 2.0 scopes.
+
 -   <a name="__input_gemini_api_key"></a><a href="#user-content-__input_gemini_api_key"><code>gemini_api_key</code></a>: _(Optional)_ The API key for the Gemini API.
 
 -   <a name="__input_gemini_cli_version"></a><a href="#user-content-__input_gemini_cli_version"><code>gemini_cli_version</code></a>: _(Optional, default: `latest`)_ The version of the Gemini CLI to install. Can be "latest", "preview", "nightly", a specific version number, or a git branch, tag, or commit. For more information, see [Gemini CLI releases](https://github.com/google-gemini/gemini-cli/blob/main/docs/releases.md).
@@ -209,7 +213,7 @@ We recommend setting the following values as repository variables so they can be
 | `GEMINI_CLI_VERSION`        | Controls which version of the Gemini CLI is installed. | Variable | No       | Pinning the CLI version   |
 | `GCP_WIF_PROVIDER`          | Full resource name of the Workload Identity Provider.  | Variable | No       | Using Google Cloud        |
 | `GOOGLE_CLOUD_PROJECT`      | Google Cloud project for inference and observability.  | Variable | No       | Using Google Cloud        |
-| `SERVICE_ACCOUNT_EMAIL`     | Google Cloud service account email address.            | Variable | No       | Using Google Cloud        |
+| `SERVICE_ACCOUNT_EMAIL`     | Google Cloud service account email address. Optional - only needed for WIF with service account (not required for direct WIF). | Variable | No       | Using WIF with service account |
 | `GOOGLE_CLOUD_LOCATION`     | Region of the Google Cloud project.                    | Variable | No       | Using Google Cloud        |
 | `GOOGLE_GENAI_USE_VERTEXAI` | Set to `true` to use Vertex AI                         | Variable | No       | Using Vertex AI           |
 | `GOOGLE_GENAI_USE_GCA`      | Set to `true` to use Gemini Code Assist                | Variable | No       | Using Gemini Code Assist  |

--- a/action.yml
+++ b/action.yml
@@ -30,6 +30,14 @@ inputs:
   gcp_workload_identity_provider:
     description: 'The Google Cloud Workload Identity Provider.'
     required: false
+  gcp_token_format:
+    description: 'The token format for authentication. Set to "access_token" to generate access tokens (requires service account), or set to empty string for direct WIF. Can be "access_token" or "id_token".'
+    required: false
+    default: 'access_token'
+  gcp_access_token_scopes:
+    description: 'The access token scopes when using token_format "access_token". Comma-separated list of OAuth 2.0 scopes.'
+    required: false
+    default: 'https://www.googleapis.com/auth/cloud-platform,https://www.googleapis.com/auth/userinfo.email,https://www.googleapis.com/auth/userinfo.profile'
   gemini_api_key:
     description: 'The API key for the Gemini API.'
     required: false
@@ -123,8 +131,13 @@ runs:
 
         # Validate Workload Identity Federation inputs
         if [[ "${INPUT_GCP_WORKLOAD_IDENTITY_PROVIDER_PRESENT:-false}" == "true" ]]; then
-          if [[ "${INPUT_GCP_PROJECT_ID_PRESENT:-false}" != "true" || "${INPUT_GCP_SERVICE_ACCOUNT_PRESENT:-false}" != "true" ]]; then
-            warn "When using Workload Identity Federation ('gcp_workload_identity_provider'), you must also provide 'gcp_project_id' and 'gcp_service_account'."
+          if [[ "${INPUT_GCP_PROJECT_ID_PRESENT:-false}" != "true" ]]; then
+            warn "When using Workload Identity Federation ('gcp_workload_identity_provider'), you must also provide 'gcp_project_id'."
+          fi
+          # Service account is required when using token_format (default behavior)
+          # Only optional when explicitly set to empty for direct WIF
+          if [[ "${INPUT_GCP_TOKEN_FORMAT}" != "" && "${INPUT_GCP_SERVICE_ACCOUNT_PRESENT:-false}" != "true" ]]; then
+            warn "When using Workload Identity Federation with token generation ('gcp_token_format'), you must also provide 'gcp_service_account'. To use direct WIF without a service account, explicitly set 'gcp_token_format' to an empty string."
           fi
           if [[ "${INPUT_USE_VERTEX_AI:-false}" == "${INPUT_USE_GEMINI_CODE_ASSIST:-false}" ]]; then
             warn "When using Workload Identity Federation, you must set exactly one of 'use_vertex_ai' or 'use_gemini_code_assist' to 'true'."
@@ -153,6 +166,7 @@ runs:
         INPUT_GCP_WORKLOAD_IDENTITY_PROVIDER_PRESENT: "${{ inputs.gcp_workload_identity_provider != '' }}"
         INPUT_GCP_PROJECT_ID_PRESENT: "${{ inputs.gcp_project_id != '' }}"
         INPUT_GCP_SERVICE_ACCOUNT_PRESENT: "${{ inputs.gcp_service_account != '' }}"
+        INPUT_GCP_TOKEN_FORMAT: '${{ inputs.gcp_token_format }}'
         INPUT_USE_VERTEX_AI: '${{ inputs.use_vertex_ai }}'
         INPUT_USE_GEMINI_CODE_ASSIST: '${{ inputs.use_gemini_code_assist }}'
 
@@ -184,8 +198,8 @@ runs:
         project_id: '${{ inputs.gcp_project_id }}'
         workload_identity_provider: '${{ inputs.gcp_workload_identity_provider }}'
         service_account: '${{ inputs.gcp_service_account }}'
-        token_format: 'access_token'
-        access_token_scopes: 'https://www.googleapis.com/auth/cloud-platform,https://www.googleapis.com/auth/userinfo.email,https://www.googleapis.com/auth/userinfo.profile'
+        token_format: '${{ inputs.gcp_token_format }}'
+        access_token_scopes: '${{ inputs.gcp_access_token_scopes }}'
 
     - name: 'Install Gemini CLI'
       id: 'install'

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -196,6 +196,9 @@ After running the `setup_workload_identity.sh` script, add the following variabl
       Explain this code
 ```
 
+> [!NOTE]
+> You can use direct Workload Identity Federation without a service account by setting `gcp_token_format: ''` and omitting `gcp_service_account`.
+
 #### Connecting to Gemini Code Assist
 
 If you have a **Gemini Code Assist** subscription, you can configure the action to use it for authentication.
@@ -229,6 +232,9 @@ After running the `setup_workload_identity.sh` script, add the following variabl
     prompt: |-
       Explain this code
 ```
+
+> [!NOTE]
+> You can use direct Workload Identity Federation without a service account by setting `gcp_token_format: ''` and omitting `gcp_service_account`.
 
 ## GitHub Authentication
 


### PR DESCRIPTION
<!--
Thank you for proposing a pull request! Please note that SOME TESTS WILL
LIKELY FAIL due to how GitHub exposes secrets in Pull Requests from forks.
Someone from the team will review your Pull Request and respond.

Please describe your change and any implementation details below.
-->

### Why this change?

Fix #379 - Service account is not actually optional, but it says so in the [README](https://github.com/google-github-actions/run-gemini-cli#inputs).

### What?

- Add support for direct WIF my making `access_token` and `gcp_access_token_scopes` into configurable inputs.

### Notes

- This is not a backwards compatibility breaking change, as I added the current values into the new inputs' defaults.
- Another approach could be to not introduce any new inputs, and instead have two variants of the authentication step; one that works like today, and one which doesn't set `access_token` if no service account was specified. This would require some minor changes to the WIF validation logic in the action.