### PR TITLE
feat(telemetry): set GHA_NAME dynamically from workflow

### DIFF
--- a/.github/workflows/gemini-invoke.yml
+++ b/.github/workflows/gemini-invoke.yml
@@ -62,6 +62,7 @@ jobs:
           use_gemini_code_assist: '${{ vars.GOOGLE_GENAI_USE_GCA }}'
           use_vertex_ai: '${{ vars.GOOGLE_GENAI_USE_VERTEXAI }}'
           upload_artifacts: '${{ vars.UPLOAD_ARTIFACTS }}'
+          workflow_name: 'gemini-invoke'
           settings: |-
             {
               "model": {

--- a/.github/workflows/gemini-review.yml
+++ b/.github/workflows/gemini-review.yml
@@ -64,6 +64,7 @@ jobs:
           use_gemini_code_assist: '${{ vars.GOOGLE_GENAI_USE_GCA }}'
           use_vertex_ai: '${{ vars.GOOGLE_GENAI_USE_VERTEXAI }}'
           upload_artifacts: '${{ vars.UPLOAD_ARTIFACTS }}'
+          workflow_name: 'gemini-review'
           settings: |-
             {
               "model": {

--- a/.github/workflows/gemini-scheduled-triage.yml
+++ b/.github/workflows/gemini-scheduled-triage.yml
@@ -108,6 +108,7 @@ jobs:
           use_gemini_code_assist: '${{ vars.GOOGLE_GENAI_USE_GCA }}'
           use_vertex_ai: '${{ vars.GOOGLE_GENAI_USE_VERTEXAI }}'
           upload_artifacts: '${{ vars.UPLOAD_ARTIFACTS }}'
+          workflow_name: 'gemini-scheduled-triage'
           settings: |-
             {
               "model": {

--- a/.github/workflows/gemini-triage.yml
+++ b/.github/workflows/gemini-triage.yml
@@ -78,6 +78,7 @@ jobs:
           use_gemini_code_assist: '${{ vars.GOOGLE_GENAI_USE_GCA }}'
           use_vertex_ai: '${{ vars.GOOGLE_GENAI_USE_VERTEXAI }}'
           upload_artifacts: '${{ vars.UPLOAD_ARTIFACTS }}'
+          workflow_name: 'gemini-triage'
           settings: |-
             {
               "model": {

--- a/README.md
+++ b/README.md
@@ -191,6 +191,8 @@ go to the [Gemini Assistant workflow documentation](./examples/workflows/gemini-
 
 -   <a name="__input_use_pnpm"></a><a href="#user-content-__input_use_pnpm"><code>use_pnpm</code></a>: _(Optional, default: `false`)_ Whether or not to use pnpm instead of npm to install gemini-cli
 
+-   <a name="__input_workflow_name"></a><a href="#user-content-__input_workflow_name"><code>workflow_name</code></a>: _(Optional, default: `${{ github.workflow }}`)_ The GitHub workflow name, used for telemetry purposes.
+
 
 <!-- END_AUTOGEN_INPUTS -->
 

--- a/action.yml
+++ b/action.yml
@@ -87,8 +87,8 @@ inputs:
     description: 'Whether or not to use pnpm instead of npm to install gemini-cli'
     required: false
     default: 'false'
-  raw_workflow_name:
-    description: 'The raw GitHub workflow name, used for telemetry purposes.'
+  workflow_name:
+    description: 'The GitHub workflow name, used for telemetry purposes.'
     required: false
     default: '${{ github.workflow }}'
 
@@ -182,10 +182,10 @@ runs:
       id: 'sanitize_workflow_name'
       shell: 'bash'
       run: |
-        SANITIZED=$(echo "${RAW_WORKFLOW_NAME}" | sed 's/[^ a-zA-Z0-9-]//g' | xargs | tr ' ' '_' | tr '[:upper:]' '[:lower:]')
+        SANITIZED=$(echo "${WORKFLOW_NAME}" | sed 's/[^ a-zA-Z0-9-]//g' | xargs | tr ' ' '_' | tr '[:upper:]' '[:lower:]')
         echo "gh_workflow_name=$SANITIZED" >> $GITHUB_OUTPUT
       env:
-        RAW_WORKFLOW_NAME: '${{ inputs.raw_workflow_name }}'
+        WORKFLOW_NAME: '${{ inputs.workflow_name }}'
 
     - name: 'Configure Gemini CLI'
       if: |-

--- a/examples/workflows/gemini-assistant/gemini-invoke.yml
+++ b/examples/workflows/gemini-assistant/gemini-invoke.yml
@@ -62,7 +62,7 @@ jobs:
           use_gemini_code_assist: '${{ vars.GOOGLE_GENAI_USE_GCA }}'
           use_vertex_ai: '${{ vars.GOOGLE_GENAI_USE_VERTEXAI }}'
           upload_artifacts: '${{ vars.UPLOAD_ARTIFACTS }}'
-          raw_workflow_name: 'gemini-invoke'
+          workflow_name: 'gemini-invoke'
           settings: |-
             {
               "model": {

--- a/examples/workflows/issue-triage/gemini-scheduled-triage.yml
+++ b/examples/workflows/issue-triage/gemini-scheduled-triage.yml
@@ -108,7 +108,7 @@ jobs:
           use_gemini_code_assist: '${{ vars.GOOGLE_GENAI_USE_GCA }}'
           use_vertex_ai: '${{ vars.GOOGLE_GENAI_USE_VERTEXAI }}'
           upload_artifacts: '${{ vars.UPLOAD_ARTIFACTS }}'
-          raw_workflow_name: 'gemini-scheduled-triage'
+          workflow_name: 'gemini-scheduled-triage'
           settings: |-
             {
               "model": {

--- a/examples/workflows/issue-triage/gemini-triage.yml
+++ b/examples/workflows/issue-triage/gemini-triage.yml
@@ -78,7 +78,7 @@ jobs:
           use_gemini_code_assist: '${{ vars.GOOGLE_GENAI_USE_GCA }}'
           use_vertex_ai: '${{ vars.GOOGLE_GENAI_USE_VERTEXAI }}'
           upload_artifacts: '${{ vars.UPLOAD_ARTIFACTS }}'
-          raw_workflow_name: 'gemini-triage'
+          workflow_name: 'gemini-triage'
           settings: |-
             {
               "model": {

--- a/examples/workflows/pr-review/gemini-review.yml
+++ b/examples/workflows/pr-review/gemini-review.yml
@@ -64,7 +64,7 @@ jobs:
           use_gemini_code_assist: '${{ vars.GOOGLE_GENAI_USE_GCA }}'
           use_vertex_ai: '${{ vars.GOOGLE_GENAI_USE_VERTEXAI }}'
           upload_artifacts: '${{ vars.UPLOAD_ARTIFACTS }}'
-          raw_workflow_name: 'gemini-review'
+          workflow_name: 'gemini-review'
           settings: |-
             {
               "model": {


### PR DESCRIPTION
Sets the GHA_NAME environment variable for the Gemini CLI action to the name of the executing workflow. This makes the telemetry data more accurate and easier to filter. A new step is added to sanitize the workflow name by removing emojis and leading/trailing whitespace, ensuring the GHA_NAME is a clean string.

