### PR TITLE
ci: auto update GitHub Actions using dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,11 @@ updates:
     commit-message:
       prefix: 'security: '
     open-pull-requests-limit: 0 # only check security updates
+
+  - package-ecosystem: 'github-actions'
+    directories:
+      - '/'
+      - '/examples/workflows/*'
+    rebase-strategy: 'disabled'
+    schedule:
+      interval: 'daily'


### PR DESCRIPTION
## Summary

CI:
- Enable Dependabot updates for GitHub Actions in the root and example workflow directories with daily checks.

Closes #272 
Related PR #261