### PR TITLE
fix #371 use JSON output of gemini cli

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -337,7 +337,7 @@ runs:
           echo "${RESPONSE}" >> "${GITHUB_OUTPUT}"
         else
           cat "${TEMP_STDOUT}" >> "${GITHUB_OUTPUT}"
-        fi  
+        fi
         echo "EOF" >> "${GITHUB_OUTPUT}"
 
         # Set the captured errors as a step output, supporting multiline


### PR DESCRIPTION
Fixes #371 
Using JSON output of Gemini CLI 

Test Scenarios:

1. Created an ISSUE which caused failure and verified the output to be in json format:

<img width="2310" height="292" alt="image" src="https://github.com/user-attachments/assets/21459bc7-bb89-4852-948e-2f945c28a904" />

2. Created a PULL request and verified the positive response was on JSON format.

<img width="1426" height="1560" alt="image" src="https://github.com/user-attachments/assets/48e30e57-1d2d-4cb4-82b0-a3afb82598d0" />

