### PR TITLE
fix: detect silent failures in gemini-cli by checking for invalid JSO…

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -326,8 +326,13 @@ runs:
         if jq -e . "${TEMP_STDERR}" >/dev/null 2>&1; then
            ERROR_JSON=$(jq -c '.error // empty' "${TEMP_STDERR}")
         fi
-        if ! { jq -e . "${TEMP_STDERR}" >/dev/null 2>&1 && jq -e . "${TEMP_STDOUT}" >/dev/null 2>&1; }; then
+        if ! jq -e . "${TEMP_STDOUT}" >/dev/null 2>&1; then
           echo "::warning::Gemini CLI output was not valid JSON"
+          # If we failed to parse JSON and the command didn't fail, this is likely a silent failure (e.g. resource limit)
+          if [[ "${FAILED}" == "false" ]]; then
+             echo "::error title=Gemini CLI execution failed::Gemini CLI produced invalid or empty JSON output, which usually indicates a silent failure."
+             FAILED=true
+          fi
         fi
 
 


### PR DESCRIPTION
I have updated the run-gemini-cli action to detect silent failures where the gemini CLI command produces no output (or invalid JSON) but exits with success (0). This typically happens when API resource limits are exceeded in non-interactive mode.

Verification Results
Automated Verification
I created a reproduction script >_reproduce_issue.sh that tested two scenarios:

1. Success Case: gemini exits with 0, produces valid JSON stdout, and empty stderr. -> PASSED (Action succeeded)
2. Failure Case: gemini exits with 0, produces empty stdout, and empty stderr. -> PASSED (Action failed as expected)

This confirms that the action now correctly catches the silent failure mode without introducing false positives for normal success cases where stderr is empty.

[Fixes #1088](https://github.com/google-gemini/gemini-cli/issues/1088)