### PR TITLE
ci(mcp): version up GitHub MCP Server

### DIFF
--- a/.github/workflows/gemini-invoke.yml
+++ b/.github/workflows/gemini-invoke.yml
@@ -82,12 +82,11 @@ jobs:
                     "--rm",
                     "-e",
                     "GITHUB_PERSONAL_ACCESS_TOKEN",
-                    "ghcr.io/github/github-mcp-server:v0.18.0"
+                    "ghcr.io/github/github-mcp-server:v0.27.0"
                   ],
                   "includeTools": [
                     "add_issue_comment",
-                    "get_issue",
-                    "get_issue_comments",
+                    "issue_read",
                     "list_issues",
                     "search_issues",
                     "create_pull_request",

--- a/.github/workflows/gemini-issue-fixer.yml
+++ b/.github/workflows/gemini-issue-fixer.yml
@@ -78,7 +78,7 @@ jobs:
                     "--rm",
                     "-e",
                     "GITHUB_PERSONAL_ACCESS_TOKEN",
-                    "ghcr.io/github/github-mcp-server:v0.18.0"
+                    "ghcr.io/github/github-mcp-server:v0.27.0"
                   ],
                   "env": {
                     "GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_TOKEN}"

--- a/.github/workflows/gemini-review.yml
+++ b/.github/workflows/gemini-review.yml
@@ -84,13 +84,12 @@ jobs:
                     "--rm",
                     "-e",
                     "GITHUB_PERSONAL_ACCESS_TOKEN",
-                    "ghcr.io/github/github-mcp-server:v0.18.0"
+                    "ghcr.io/github/github-mcp-server:v0.27.0"
                   ],
                   "includeTools": [
                     "add_comment_to_pending_review",
-                    "create_pending_pull_request_review",
                     "pull_request_read",
-                    "submit_pending_pull_request_review"
+                    "pull_request_review_write"
                   ],
                   "env": {
                     "GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_TOKEN}"

--- a/examples/workflows/gemini-assistant/gemini-invoke.yml
+++ b/examples/workflows/gemini-assistant/gemini-invoke.yml
@@ -82,12 +82,11 @@ jobs:
                     "--rm",
                     "-e",
                     "GITHUB_PERSONAL_ACCESS_TOKEN",
-                    "ghcr.io/github/github-mcp-server:v0.18.0"
+                    "ghcr.io/github/github-mcp-server:v0.27.0"
                   ],
                   "includeTools": [
                     "add_issue_comment",
-                    "get_issue",
-                    "get_issue_comments",
+                    "issue_read",
                     "list_issues",
                     "search_issues",
                     "create_pull_request",

--- a/examples/workflows/pr-review/gemini-review.yml
+++ b/examples/workflows/pr-review/gemini-review.yml
@@ -84,13 +84,12 @@ jobs:
                     "--rm",
                     "-e",
                     "GITHUB_PERSONAL_ACCESS_TOKEN",
-                    "ghcr.io/github/github-mcp-server:v0.18.0"
+                    "ghcr.io/github/github-mcp-server:v0.27.0"
                   ],
                   "includeTools": [
                     "add_comment_to_pending_review",
-                    "create_pending_pull_request_review",
                     "pull_request_read",
-                    "submit_pending_pull_request_review"
+                    "pull_request_review_write"
                   ],
                   "env": {
                     "GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_TOKEN}"


### PR DESCRIPTION
## Summary

Build:
- Bump github-mcp-server Docker image from [v0.18.0](https://github.com/github/github-mcp-server/releases/tag/v0.18.0) to [v0.27.0](https://github.com/github/github-mcp-server/releases/tag/v0.27.0) in GitHub Actions workflows and example workflow configurations.
- [Renamed some tools](https://github.com/github/github-mcp-server/blob/main/docs/tool-renaming.md) such as `pull_request_review_write` and `issue_read`.