### PR TITLE
docs: update a broken link of gemini cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,10 +175,10 @@ go to the [Gemini Assistant workflow documentation](./examples/workflows/gemini-
 
 -   <a name="__input_google_api_key"></a><a href="#user-content-__input_google_api_key"><code>google_api_key</code></a>: _(Optional)_ The Vertex AI API key to use with Gemini.
 
--   <a name="__input_prompt"></a><a href="#user-content-__input_prompt"><code>prompt</code></a>: _(Optional, default: `You are a helpful assistant.`)_ A string passed to the Gemini CLI's [`--prompt` argument](https://github.com/google-gemini/gemini-cli/blob/main/docs/cli/configuration.md#command-line-arguments).
+-   <a name="__input_prompt"></a><a href="#user-content-__input_prompt"><code>prompt</code></a>: _(Optional, default: `You are a helpful assistant.`)_ A string passed to the Gemini CLI's [`--prompt` argument](https://github.com/google-gemini/gemini-cli/blob/main/docs/get-started/configuration.md#command-line-arguments).
 
 -   <a name="__input_settings"></a><a href="#user-content-__input_settings"><code>settings</code></a>: _(Optional)_ A JSON string written to `.gemini/settings.json` to configure the CLI's _project_ settings.
-    For more details, see the documentation on [settings files](https://github.com/google-gemini/gemini-cli/blob/main/docs/cli/configuration.md#settings-files).
+    For more details, see the documentation on [settings files][settings_json].
 
 -   <a name="__input_use_gemini_code_assist"></a><a href="#user-content-__input_use_gemini_code_assist"><code>use_gemini_code_assist</code></a>: _(Optional, default: `false`)_ Whether to use Code Assist for Gemini model access instead of the default Gemini API key.
     For more information, see the [Gemini CLI documentation](https://github.com/google-gemini/gemini-cli/blob/main/docs/cli/authentication.md).
@@ -324,11 +324,11 @@ Contributions are welcome! Check out the Gemini CLI
 started.
 
 [secrets]: https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions
-[settings_json]: https://github.com/google-gemini/gemini-cli/blob/main/docs/cli/configuration.md#settings-files
+[settings_json]: https://github.com/google-gemini/gemini-cli/blob/main/docs/get-started/configuration.md#settings-files
 [Gemini]: https://deepmind.google/models/gemini/
 [Google AI Studio]: https://aistudio.google.com/apikey
 [Gemini CLI]: https://github.com/google-gemini/gemini-cli/
 [Google Cloud support]: https://cloud.google.com/support
 [variables]: https://docs.github.com/en/actions/how-tos/write-workflows/choose-what-workflows-do/use-variables#creating-configuration-variables-for-a-repository
 [GitHub CLI]: https://docs.github.com/en/github-cli/github-cli
-[GEMINI.md]: https://github.com/google-gemini/gemini-cli/blob/main/docs/cli/configuration.md#context-files-hierarchical-instructional-context
+[GEMINI.md]: https://github.com/google-gemini/gemini-cli/blob/main/docs/get-started/configuration.md#context-files-hierarchical-instructional-context

--- a/action.yml
+++ b/action.yml
@@ -56,13 +56,13 @@ inputs:
     required: false
   prompt:
     description: |-
-      A string passed to the Gemini CLI's [`--prompt` argument](https://github.com/google-gemini/gemini-cli/blob/main/docs/cli/configuration.md#command-line-arguments).
+      A string passed to the Gemini CLI's [`--prompt` argument](https://github.com/google-gemini/gemini-cli/blob/main/docs/get-started/configuration.md#command-line-arguments).
     required: false
     default: 'You are a helpful assistant.'
   settings:
     description: |-
       A JSON string written to `.gemini/settings.json` to configure the CLI's _project_ settings.
-      For more details, see the documentation on [settings files](https://github.com/google-gemini/gemini-cli/blob/main/docs/cli/configuration.md#settings-files).
+      For more details, see the documentation on [settings files](https://github.com/google-gemini/gemini-cli/blob/main/docs/get-started/configuration.md#settings-files).
     required: false
   use_gemini_code_assist:
     description: |-

--- a/examples/workflows/CONFIGURATION.md
+++ b/examples/workflows/CONFIGURATION.md
@@ -18,7 +18,7 @@ This guide covers how to customize and configure Gemini CLI workflows to meet yo
 
 Gemini CLI workflows are highly configurable. You can adjust their behavior by editing the corresponding `.yml` files in your repository.
 
-Gemini CLI supports many settings that control how it operates. For a complete list, see the [Gemini CLI documentation](https://github.com/google-gemini/gemini-cli/blob/main/docs/cli/configuration.md#available-settings-in-settingsjson).
+Gemini CLI supports many settings that control how it operates. For a complete list, see the [Gemini CLI documentation](https://github.com/google-gemini/gemini-cli/blob/main/docs/get-started/configuration.md#available-settings-in-settingsjson).
 
 ### Custom Commands (TOML Files)
 


### PR DESCRIPTION
## Summary

Documentation:
- Update the README to point the Gemini CLI reference link to the correct configuration documentation path.

| Before | After |
|--------|--------|
| https://github.com/google-gemini/gemini-cli/blob/main/docs/cli/configuration.md | https://github.com/google-gemini/gemini-cli/blob/main/docs/get-started/configuration.md |

Ref: [docs: Remove redundant and duplicate documentation files #14699](https://github.com/google-gemini/gemini-cli/pull/14699)