### PR TITLE
docs: update an authentication documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,10 +181,10 @@ go to the [Gemini Assistant workflow documentation](./examples/workflows/gemini-
     For more details, see the documentation on [settings files](https://github.com/google-gemini/gemini-cli/blob/main/docs/get-started/configuration.md#settings-files).
 
 -   <a name="__input_use_gemini_code_assist"></a><a href="#user-content-__input_use_gemini_code_assist"><code>use_gemini_code_assist</code></a>: _(Optional, default: `false`)_ Whether to use Code Assist for Gemini model access instead of the default Gemini API key.
-    For more information, see the [Gemini CLI documentation](https://github.com/google-gemini/gemini-cli/blob/main/docs/cli/authentication.md).
+    For more information, see the [Gemini CLI documentation](https://github.com/google-gemini/gemini-cli/blob/main/docs/get-started/authentication.md).
 
 -   <a name="__input_use_vertex_ai"></a><a href="#user-content-__input_use_vertex_ai"><code>use_vertex_ai</code></a>: _(Optional, default: `false`)_ Whether to use Vertex AI for Gemini model access instead of the default Gemini API key.
-    For more information, see the [Gemini CLI documentation](https://github.com/google-gemini/gemini-cli/blob/main/docs/cli/authentication.md).
+    For more information, see the [Gemini CLI documentation](https://github.com/google-gemini/gemini-cli/blob/main/docs/get-started/authentication.md).
 
 -   <a name="__input_extensions"></a><a href="#user-content-__input_extensions"><code>extensions</code></a>: _(Optional)_ A list of Gemini CLI extensions to install.
 

--- a/action.yml
+++ b/action.yml
@@ -67,13 +67,13 @@ inputs:
   use_gemini_code_assist:
     description: |-
       Whether to use Code Assist for Gemini model access instead of the default Gemini API key.
-      For more information, see the [Gemini CLI documentation](https://github.com/google-gemini/gemini-cli/blob/main/docs/cli/authentication.md).
+      For more information, see the [Gemini CLI documentation](https://github.com/google-gemini/gemini-cli/blob/main/docs/get-started/authentication.md).
     required: false
     default: 'false'
   use_vertex_ai:
     description: |-
       Whether to use Vertex AI for Gemini model access instead of the default Gemini API key.
-      For more information, see the [Gemini CLI documentation](https://github.com/google-gemini/gemini-cli/blob/main/docs/cli/authentication.md).
+      For more information, see the [Gemini CLI documentation](https://github.com/google-gemini/gemini-cli/blob/main/docs/get-started/authentication.md).
     required: false
     default: 'false'
   extensions:


### PR DESCRIPTION
## Summary

Update Gemini CLI authentication documentation links to the new get-started path.

Documentation:
- Refresh README references to Gemini CLI authentication docs to point to the updated get-started URL.

Chores:
- Align action input descriptions with the new Gemini CLI authentication documentation URL.

| Before | After |
|--------|--------|
| <img width="818" height="383" alt="before" src="https://github.com/user-attachments/assets/3702e4ca-e7c7-4eae-92b6-e87f7ae943cc" /> | <img width="1533" height="614" alt="after" src="https://github.com/user-attachments/assets/c9bccadb-85ff-4cff-933e-2072ccbfa8fa" /> | 