### PR TITLE
fix(setup): Gracefully handle internal-only Cloud

### DIFF
--- a/scripts/setup_workload_identity.sh
+++ b/scripts/setup_workload_identity.sh
@@ -219,7 +219,9 @@ required_apis=(
     "monitoring.googleapis.com"
     "sts.googleapis.com"
 )
-
+# Separately enable the internal-only Cloud Code API, ignoring errors
+# for public users who may not have access.
+gcloud services enable "cloudcode-pa.googleapis.com" --project="${GOOGLE_CLOUD_PROJECT}" || true
 gcloud services enable "${required_apis[@]}" --project="${GOOGLE_CLOUD_PROJECT}"
 gcloud services enable "cloudcode-pa.googleapis.com" --project="${GOOGLE_CLOUD_PROJECT}" || true
 print_success "APIs enabled successfully."


### PR DESCRIPTION
Code API enablement Modify `setup_workload_identity.sh` to prevent script failure when enabling the internal-only `cloudcode-pa.googleapis.com` API. The API enablement command now includes `|| true`, allowing the script to continue for public users without permissions for this service.

<!--
Thank you for proposing a pull request! Please note that SOME TESTS WILL
LIKELY FAIL due to how GitHub exposes secrets in Pull Requests from forks.
Someone from the team will review your Pull Request and respond.

Please describe your change and any implementation details below.
-->
