### PR TITLE
Release: v0.1.20

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "run-gemini-cli",
-  "version": "0.1.19",
+  "version": "0.1.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "run-gemini-cli",
-      "version": "0.1.19",
+      "version": "0.1.20",
       "license": "Apache-2.0",
       "devDependencies": {
         "@google-github-actions/actions-utils": "^0.8.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "run-gemini-cli",
-  "version": "0.1.19",
+  "version": "0.1.20",
   "description": "This works with our versioning tools, this is NOT an NPM repo",
   "scripts": {
     "build": "echo \"No build required for composite action\"",


### PR DESCRIPTION
## What's Changed

### Bug Fixes

* fix(setup): Gracefully handle internal-only Cloud by @spencer426 in https://github.com/google-github-actions/run-gemini-cli/pull/447

### Documentation

* docs: update a broken link of gemini cli by @Marukome0743 in https://github.com/google-github-actions/run-gemini-cli/pull/441

### Other Changes

* ci(mcp): version up GitHub MCP Server by @bdmorgan in https://github.com/google-github-actions/run-gemini-cli/pull/437

**Full Changelog**: https://github.com/google-github-actions/run-gemini-cli/compare/v0.1.19...v0.1.20