### PR TITLE
Revert "Release: v0.1.20"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "run-gemini-cli",
-  "version": "0.1.20",
+  "version": "0.1.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "run-gemini-cli",
-      "version": "0.1.20",
+      "version": "0.1.19",
       "license": "Apache-2.0",
       "devDependencies": {
         "@google-github-actions/actions-utils": "^0.8.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "run-gemini-cli",
-  "version": "0.1.20",
+  "version": "0.1.19",
   "description": "This works with our versioning tools, this is NOT an NPM repo",
   "scripts": {
     "build": "echo \"No build required for composite action\"",


### PR DESCRIPTION
Reverts google-github-actions/run-gemini-cli#449

Requires github actions bot to trigger the release https://github.com/google-github-actions/run-gemini-cli/actions/runs/21486000478.