### PR TITLE
Fix summary Markdown formatting

### DIFF
--- a/examples/workflows/pr-review/gemini-review.toml
+++ b/examples/workflows/pr-review/gemini-review.toml
@@ -154,6 +154,7 @@ Apply these severities consistently:
 3. **Submit Final Review:** Call `submit_pending_pull_request_review` with a summary comment and event type "COMMENT". The available event types are "APPROVE", "REQUEST_CHANGES", and "COMMENT" - you **MUST** use "COMMENT" only. **DO NOT** use "APPROVE" or "REQUEST_CHANGES" event types. The summary comment **MUST** use this exact markdown format:
 
     <SUMMARY>
+
     ## 📋 Review Summary
 
     A brief, high-level assessment of the Pull Request's objective and quality (2-3 sentences).


### PR DESCRIPTION
Title (##) is not rendered correctly if it's just after `<SUMMARY>` tag

<!--
Thank you for proposing a pull request! Please note that SOME TESTS WILL
LIKELY FAIL due to how GitHub exposes secrets in Pull Requests from forks.
Someone from the team will review your Pull Request and respond.

Please describe your change and any implementation details below.
-->

<img width="675" height="370" alt="image" src="https://github.com/user-attachments/assets/e33775b2-2c6d-4b26-a5f8-4493e42fd58c" />

If we add a new line between:

<img width="699" height="474" alt="image" src="https://github.com/user-attachments/assets/931524cd-6d8f-4e33-a857-75befc565553" />
