### PR TITLE
fix: typo workflow_name on gemini-plan-execute

### DIFF
--- a/.github/workflows/gemini-plan-execute.yml
+++ b/.github/workflows/gemini-plan-execute.yml
@@ -67,7 +67,7 @@ jobs:
           use_gemini_code_assist: '${{ vars.GOOGLE_GENAI_USE_GCA }}'
           use_vertex_ai: '${{ vars.GOOGLE_GENAI_USE_VERTEXAI }}'
           upload_artifacts: '${{ vars.UPLOAD_ARTIFACTS }}'
-          workflow_name: 'gemini-invoke'
+          workflow_name: 'gemini-plan-execute'
           settings: |-
             {
               "model": {

--- a/examples/workflows/gemini-assistant/gemini-plan-execute.yml
+++ b/examples/workflows/gemini-assistant/gemini-plan-execute.yml
@@ -67,7 +67,7 @@ jobs:
           use_gemini_code_assist: '${{ vars.GOOGLE_GENAI_USE_GCA }}'
           use_vertex_ai: '${{ vars.GOOGLE_GENAI_USE_VERTEXAI }}'
           upload_artifacts: '${{ vars.UPLOAD_ARTIFACTS }}'
-          workflow_name: 'gemini-invoke'
+          workflow_name: 'gemini-plan-execute'
           settings: |-
             {
               "model": {


### PR DESCRIPTION
## Summary

Enhancements:
- Align the workflow_name metadata in the Gemini plan-execute GitHub workflow and example with the actual workflow file name.

Follow up #465 