### PR TITLE
Fix: Add workflow name to telemetry resource attributes

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -456,6 +456,7 @@ runs:
             -e "s#GITHUB_RUN_ID_PLACEHOLDER#${GITHUB_RUN_ID}#g" \
             -e "s#GITHUB_PR_NUMBER_PLACEHOLDER#${GITHUB_PR_NUMBER}#g" \
             -e "s#GITHUB_ISSUE_NUMBER_PLACEHOLDER#${GITHUB_ISSUE_NUMBER}#g" \
+            -e "s#GITHUB_WORKFLOW_PLACEHOLDER#${GH_WORKFLOW_NAME}#g" \
           "${GITHUB_ACTION_PATH}/scripts/collector-gcp.yaml.template" > ".gemini/collector-gcp.yaml"
 
         # Ensure credentials file has the right permissions
@@ -508,6 +509,7 @@ runs:
         GITHUB_RUN_ID: '${{ github.run_id }}'
         GITHUB_PR_NUMBER: '${{ inputs.github_pr_number }}'
         GITHUB_ISSUE_NUMBER: '${{ inputs.github_issue_number }}'
+        GH_WORKFLOW_NAME: '${{ steps.sanitize_workflow_name.outputs.gh_workflow_name }}'
 
 branding:
   icon: 'terminal'

--- a/scripts/collector-gcp.yaml.template
+++ b/scripts/collector-gcp.yaml.template
@@ -18,6 +18,9 @@ processors:
       - key: 'github.issue.number'
         value: 'GITHUB_ISSUE_NUMBER_PLACEHOLDER'
         action: 'upsert'
+      - key: 'github.workflow'
+        value: 'GITHUB_WORKFLOW_PLACEHOLDER'
+        action: 'upsert'
   batch:
     send_batch_size: 100
     timeout: '10s'


### PR DESCRIPTION
This PR adds the workflow name to the OpenTelemetry resource attributes in the collector configuration. This fixes the issue where GEMINI_CLI_WORKFLOW_NAME is null in metric events for customer-triggered runs. Closes #492