### PR TITLE
Fix: fix the contradictory issue search query in `gemini-scheduled-triage`

### DIFF
--- a/.github/workflows/gemini-scheduled-triage.yml
+++ b/.github/workflows/gemini-scheduled-triage.yml
@@ -73,7 +73,7 @@ jobs:
           echo '🔍 Finding unlabeled issues and issues marked for triage...'
           ISSUES="$(gh issue list \
             --state 'open' \
-            --search 'no:label label:"status/needs-triage"' \
+            --search 'no:label OR label:"status/needs-triage"' \
             --json number,title,body \
             --limit '100' \
             --repo "${GITHUB_REPOSITORY}"

--- a/examples/workflows/issue-triage/gemini-scheduled-triage.yml
+++ b/examples/workflows/issue-triage/gemini-scheduled-triage.yml
@@ -73,7 +73,7 @@ jobs:
           echo '🔍 Finding unlabeled issues and issues marked for triage...'
           ISSUES="$(gh issue list \
             --state 'open' \
-            --search 'no:label label:"status/needs-triage"' \
+            --search 'no:label OR label:"status/needs-triage"' \
             --json number,title,body \
             --limit '100' \
             --repo "${GITHUB_REPOSITORY}"


### PR DESCRIPTION
<!--
Thank you for proposing a pull request! Please note that SOME TESTS WILL
LIKELY FAIL due to how GitHub exposes secrets in Pull Requests from forks.
Someone from the team will review your Pull Request and respond.

Please describe your change and any implementation details below.
-->

Fixes #499.

This PR fixes the contradictory search query used by `gemini-scheduled-triage` when collecting issues to triage. 

### What changed

Updated the query from:

`no:label label:"status/needs-triage"`

to:

`no:label OR label:"status/needs-triage"`

in both:

  - `.github/workflows/gemini-scheduled-triage.yml`
  - `examples/workflows/issue-triage/gemini-scheduled-triage.yml`