### PR TITLE
fix: trust workspace for gemini-cli 0.39.1+ in CI

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -237,6 +237,7 @@ runs:
       id: 'install'
       env:
         GEMINI_CLI_VERSION: '${{ inputs.gemini_cli_version }}'
+        GEMINI_CLI_TRUST_WORKSPACE: 'true'
         EXTENSIONS: '${{ inputs.extensions }}'
         USE_PNPM: '${{ inputs.use_pnpm }}'
         SURFACE: 'GitHub'
@@ -416,6 +417,7 @@ runs:
       env:
         GEMINI_DEBUG: '${{ fromJSON(inputs.gemini_debug || false) }}'
         GEMINI_API_KEY: '${{ inputs.gemini_api_key }}'
+        GEMINI_CLI_TRUST_WORKSPACE: 'true'
         SURFACE: 'GitHub'
         GOOGLE_CLOUD_PROJECT: '${{ inputs.gcp_project_id }}'
         GOOGLE_CLOUD_LOCATION: '${{ inputs.gcp_location }}'


### PR DESCRIPTION
## Summary
- set `GEMINI_CLI_TRUST_WORKSPACE=true` when installing and running Gemini CLI in the action
- fix compatibility with `gemini-cli` 0.39.1+ trusted-directory enforcement in headless CI

## Testing
- verified the action wiring locally by inspecting the composite action diff
- validated the fix against the failure mode reported in #503

Closes #503