### PR TITLE
fix: use GEMINI_CLI_TRUST_WORKSPACE in example workflows

### DIFF
--- a/docs/trust-guidance.md
+++ b/docs/trust-guidance.md
@@ -1,6 +1,6 @@
 # Gemini-CLI Specific GitHub Actions (GHA) Trust Guidance
 
-This guide outlines essential security configurations and best practices for integrating the Gemini CLI with your GitHub Actions (GHA) workflows. Version `0.39.1` introduces security controls for Gemini CLI in headless mode. When running Gemini CLI in CI, like GitHub Actions, you must determine if your CI workflow operates on trusted or untrusted data. If your workflow operates exclusively on trusted data, e.g., code or prompts from repo owners, you can safely set `GEMINI_TRUST_WORKSPACE=true`. If your workflow operates on untrusted data, follow the guidance below, and set the environment variable after hardening your workflow.
+This guide outlines essential security configurations and best practices for integrating the Gemini CLI with your GitHub Actions (GHA) workflows. Version `0.39.1` introduces security controls for Gemini CLI in headless mode. When running Gemini CLI in CI, like GitHub Actions, you must determine if your CI workflow operates on trusted or untrusted data. If your workflow operates exclusively on trusted data, e.g., code or prompts from repo owners, you can safely set `GEMINI_CLI_TRUST_WORKSPACE=true`. If your workflow operates on untrusted data, follow the guidance below, and set the environment variable after hardening your workflow.
 
 **1\. Determine if your workflow processes untrusted data**
 
@@ -8,7 +8,7 @@ The required security configuration for your workflow depends on the origin of t
 
 | Data Trust Level                                                                      | Required Configuration & Action                                                             |
 | ------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
-| **Fully Trusted Data** e.g. any inputs from high-trust collaborators.                 | Set `GEMINI_TRUST_WORKSPACE=true` in your workflow.                                         |
+| **Fully Trusted Data** e.g. any inputs from high-trust collaborators.                 | Set `GEMINI_CLI_TRUST_WORKSPACE=true` in your workflow.                                     |
 | **Untrusted Data** e.g. GitHub issues or pull requests submitted by non-collaborators | Follow the guidelines below to harden your workflow, and then set the environment variable. |
 
 **2\. Permissions and Principle of Least Privilege**

--- a/examples/workflows/gemini-assistant/gemini-invoke.yml
+++ b/examples/workflows/gemini-assistant/gemini-invoke.yml
@@ -68,7 +68,7 @@ jobs:
         id: 'run_gemini'
         uses: 'google-github-actions/run-gemini-cli@v0' # ratchet:exclude
         env:
-          GEMINI_TRUST_WORKSPACE: 'true'
+          GEMINI_CLI_TRUST_WORKSPACE: 'true'
           GITHUB_TOKEN: '${{ steps.mint_identity_token.outputs.token || secrets.GITHUB_TOKEN || github.token }}'
         with:
           gcp_location: '${{ vars.GOOGLE_CLOUD_LOCATION }}'

--- a/examples/workflows/gemini-assistant/gemini-plan-execute.yml
+++ b/examples/workflows/gemini-assistant/gemini-plan-execute.yml
@@ -70,7 +70,7 @@ jobs:
         id: 'run_gemini'
         uses: 'google-github-actions/run-gemini-cli@v0' # ratchet:exclude
         env:
-          GEMINI_TRUST_WORKSPACE: 'true'
+          GEMINI_CLI_TRUST_WORKSPACE: 'true'
           GITHUB_TOKEN: '${{ steps.mint_identity_token.outputs.token || secrets.GITHUB_TOKEN || github.token }}'
         with:
           gcp_location: '${{ vars.GOOGLE_CLOUD_LOCATION }}'

--- a/examples/workflows/issue-triage/gemini-scheduled-triage.yml
+++ b/examples/workflows/issue-triage/gemini-scheduled-triage.yml
@@ -106,7 +106,7 @@ jobs:
           ${{ steps.find_issues.outputs.issues_to_triage != '[]' }}
         uses: 'google-github-actions/run-gemini-cli@v0' # ratchet:exclude
         env:
-          GEMINI_TRUST_WORKSPACE: 'true'
+          GEMINI_CLI_TRUST_WORKSPACE: 'true'
           GITHUB_TOKEN: '' # Do not pass any auth token here since this runs on untrusted inputs
         with:
           gcp_location: '${{ vars.GOOGLE_CLOUD_LOCATION }}'

--- a/examples/workflows/issue-triage/gemini-triage.yml
+++ b/examples/workflows/issue-triage/gemini-triage.yml
@@ -75,7 +75,7 @@ jobs:
           ${{ steps.get_labels.outputs.available_labels != '' }}
         uses: 'google-github-actions/run-gemini-cli@v0' # ratchet:exclude
         env:
-          GEMINI_TRUST_WORKSPACE: 'true'
+          GEMINI_CLI_TRUST_WORKSPACE: 'true'
           GITHUB_TOKEN: '' # Do NOT pass any auth tokens here since this runs on untrusted inputs
         with:
           gcp_location: '${{ vars.GOOGLE_CLOUD_LOCATION }}'

--- a/examples/workflows/pr-review/gemini-review.yml
+++ b/examples/workflows/pr-review/gemini-review.yml
@@ -61,7 +61,7 @@ jobs:
         uses: 'google-github-actions/run-gemini-cli@v0' # ratchet:exclude
         id: 'gemini_pr_review'
         env:
-          GEMINI_TRUST_WORKSPACE: 'true'
+          GEMINI_CLI_TRUST_WORKSPACE: 'true'
           GITHUB_TOKEN: '${{ steps.mint_identity_token.outputs.token || secrets.GITHUB_TOKEN || github.token }}'
           GEMINI_API_KEY: '${{ secrets.GEMINI_API_KEY }}'
         with:


### PR DESCRIPTION
Fix example workflows to use `GEMINI_CLI_TRUST_WORKSPACE` instead of `GEMINI_TRUST_WORKSPACE`.

Closes #506.