### PR TITLE
fix: use OR operator in scheduled triage issue search query

### DIFF
--- a/examples/workflows/issue-triage/gemini-scheduled-triage.yml
+++ b/examples/workflows/issue-triage/gemini-scheduled-triage.yml
@@ -73,7 +73,7 @@ jobs:
           echo '🔍 Finding unlabeled issues and issues marked for triage...'
           ISSUES="$(gh issue list \
             --state 'open' \
-            --search 'no:label label:"status/needs-triage"' \
+            --search 'no:label OR label:"status/needs-triage"' \
             --json number,title,body \
             --limit '100' \
             --repo "${GITHUB_REPOSITORY}"


### PR DESCRIPTION
## Summary

The `--search` flag in the "Find untriaged issues" step of `gemini-scheduled-triage.yml` uses:

```
no:label label:"status/needs-triage"
```

GitHub interprets this as `AND` — an issue cannot simultaneously have no labels **and** carry the `status/needs-triage` label, so the query always returns zero results.

This PR switches to:

```
no:label OR label:"status/needs-triage"
```

so the step correctly finds issues that either have no labels **or** are explicitly marked for triage.

Fixes #499

## Test plan

- Verified that `gh issue list --search 'no:label OR label:"status/needs-triage"'` returns the expected union of unlabeled issues and triage-labeled issues