### PR TITLE
chore: align checkout steps with standard practices

### DIFF
--- a/.github/workflows/evals-nightly.yml
+++ b/.github/workflows/evals-nightly.yml
@@ -21,6 +21,8 @@ jobs:
     steps:
       - name: 'Checkout code'
         uses: 'actions/checkout@v4' # ratchet:exclude
+        with:
+          persist-credentials: false
       - id: 'set-matrix'
         run: |
           FILES=$(find evals -maxdepth 1 -name "*.eval.ts" | sort | jq -R -s -c 'split("\n")[:-1]')
@@ -39,6 +41,8 @@ jobs:
     steps:
       - name: 'Checkout code'
         uses: 'actions/checkout@v4' # ratchet:exclude
+        with:
+          persist-credentials: false
 
       - name: 'Set up Node.js'
         uses: 'actions/setup-node@v4' # ratchet:exclude
@@ -90,6 +94,8 @@ jobs:
     steps:
       - name: 'Checkout code'
         uses: 'actions/checkout@v4' # ratchet:exclude
+        with:
+          persist-credentials: false
 
       - name: 'Set up Node.js'
         uses: 'actions/setup-node@v4' # ratchet:exclude

--- a/.github/workflows/gemini-invoke.yml
+++ b/.github/workflows/gemini-invoke.yml
@@ -40,7 +40,7 @@ jobs:
       - name: 'Checkout Code'
         uses: 'actions/checkout@v4' # ratchet:exclude
         with:
-          persist-credentials: 'false'
+          persist-credentials: false
 
       - name: 'Prepare prompt context'
         shell: 'bash'

--- a/.github/workflows/gemini-issue-fixer.yml
+++ b/.github/workflows/gemini-issue-fixer.yml
@@ -38,7 +38,7 @@ jobs:
       - name: 'Checkout repository'
         uses: 'actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8' # ratchet:actions/checkout@v6
         with:
-          persist-credentials: 'false'
+          persist-credentials: false
 
       - name: 'Prepare prompt context'
         shell: 'bash'

--- a/.github/workflows/gemini-plan-execute.yml
+++ b/.github/workflows/gemini-plan-execute.yml
@@ -42,7 +42,7 @@ jobs:
       - name: 'Checkout Code'
         uses: 'actions/checkout@v4' # ratchet:exclude
         with:
-          persist-credentials: 'false'
+          persist-credentials: false
 
       - name: 'Prepare prompt context'
         shell: 'bash'

--- a/.github/workflows/gemini-review.yml
+++ b/.github/workflows/gemini-review.yml
@@ -41,7 +41,7 @@ jobs:
       - name: 'Checkout repository'
         uses: 'actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8' # ratchet:actions/checkout@v6
         with:
-          persist-credentials: 'false'
+          persist-credentials: false
 
       - name: 'Prepare prompt context'
         shell: 'bash'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: 'Checkout'
         uses: 'actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8' # ratchet:actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: 'Publish'
         id: 'publish'


### PR DESCRIPTION
## Description
This PR updates several GitHub workflow files to align the `actions/checkout` step with standard repository practices by setting `persist-credentials: false`.

## Changes
- Updated `.github/workflows/evals-nightly.yml`
- Updated `.github/workflows/gemini-invoke.yml`
- Updated `.github/workflows/gemini-issue-fixer.yml`
- Updated `.github/workflows/gemini-plan-execute.yml`
- Updated `.github/workflows/gemini-review.yml`
- Updated `.github/workflows/publish.yml`
