### PR TITLE
fix: randomize heredoc delimiter in GITHUB_OUTPUT writes

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -350,22 +350,24 @@ runs:
 
 
         # Set the captured response as a step output, supporting multiline
-        echo "gemini_response<<EOF" >> "${GITHUB_OUTPUT}"
+        DELIM_GEMINI_RESPONSE="ghadelim_$(openssl rand -hex 16)"
+        echo "gemini_response<<${DELIM_GEMINI_RESPONSE}" >> "${GITHUB_OUTPUT}"
         if [[ -n "${RESPONSE}" ]]; then
           echo "${RESPONSE}" >> "${GITHUB_OUTPUT}"
         else
           cat "${TEMP_STDOUT}" >> "${GITHUB_OUTPUT}"
         fi
-        echo "EOF" >> "${GITHUB_OUTPUT}"
+        echo "${DELIM_GEMINI_RESPONSE}" >> "${GITHUB_OUTPUT}"
 
         # Set the captured errors as a step output, supporting multiline
-        echo "gemini_errors<<EOF" >> "${GITHUB_OUTPUT}"
+        DELIM_GEMINI_ERRORS="ghadelim_$(openssl rand -hex 16)"
+        echo "gemini_errors<<${DELIM_GEMINI_ERRORS}" >> "${GITHUB_OUTPUT}"
         if [[ -n "${ERROR_JSON}" ]]; then
           echo "${ERROR_JSON}" >> "${GITHUB_OUTPUT}"
         else
           cat "${TEMP_STDERR}" >> "${GITHUB_OUTPUT}"
         fi
-        echo "EOF" >> "${GITHUB_OUTPUT}"
+        echo "${DELIM_GEMINI_ERRORS}" >> "${GITHUB_OUTPUT}"
 
         # Generate Job Summary
         if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then


### PR DESCRIPTION
## Summary

Randomize the heredoc delimiter used when writing `gemini_response` and `gemini_errors` to `$GITHUB_OUTPUT` in `action.yml`.

The fixed `EOF` delimiter allows an LLM response containing a bare `EOF` line to close the heredoc early. Subsequent `name=value` lines in the response then become arbitrary step outputs, enabling bash injection in downstream consumer workflows.

## Changes

- Replace `echo "gemini_response<<EOF"` with a random `ghdelim_<hex>` delimiter
- Replace `echo "gemini_errors<<EOF"` with a random `ghdelim_<hex>` delimiter
- Uses `openssl rand -hex 16` per GitHub's canonical pattern

## Testing

```bash
# Before fix: EOF in response breaks the heredoc
RESPONSE="line1\nEOF\ninjected=value"
echo "gemini_response<<EOF" >> output.txt
echo "$RESPONSE" >> output.txt
echo "EOF" >> output.txt
# Result: injected=value becomes a step output

# After fix: random delimiter is unguessable
_DELIM="ghdelim_$(openssl rand -hex 16)"
echo "gemini_response<<${_DELIM}" >> output.txt
echo "$RESPONSE" >> output.txt
echo "${_DELIM}" >> output.txt
# Result: entire response captured as gemini_response, no injection
```

Fixes #526

## References

- [GitHub docs: multiline strings](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#multiline-strings)
- Related: GHSA-62f2-6rx8-v262, PR #524 (TOML template fix)
