### PR TITLE
fix: install Gemini CLI into runner temp prefix

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -248,13 +248,18 @@ runs:
         set -euo pipefail
 
         VERSION_INPUT="${GEMINI_CLI_VERSION:-latest}"
+        GEMINI_CLI_INSTALL_PREFIX="${RUNNER_TEMP:-${HOME}}/gemini-cli-install"
+        mkdir -p "${GEMINI_CLI_INSTALL_PREFIX}/bin"
+        export PATH="${GEMINI_CLI_INSTALL_PREFIX}/bin:${PATH}"
+        echo "${GEMINI_CLI_INSTALL_PREFIX}/bin" >> "${GITHUB_PATH}"
 
         if [[ "${VERSION_INPUT}" == "latest" || "${VERSION_INPUT}" == "preview" || "${VERSION_INPUT}" == "nightly" || "${VERSION_INPUT}" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9\.-]+)?(\+[a-zA-Z0-9\.-]+)?$ ]]; then
           echo "Installing Gemini CLI from npm: @google/gemini-cli@${VERSION_INPUT}"
           if [[ "${USE_PNPM}" == "true" ]]; then
+            export PNPM_HOME="${GEMINI_CLI_INSTALL_PREFIX}/bin"
             pnpm add --silent --global @google/gemini-cli@"${VERSION_INPUT}"
           else
-            npm install --silent --no-audit --prefer-offline --global @google/gemini-cli@"${VERSION_INPUT}"
+            npm install --silent --no-audit --prefer-offline --global --prefix "${GEMINI_CLI_INSTALL_PREFIX}" @google/gemini-cli@"${VERSION_INPUT}"
           fi
         else
           echo "Installing Gemini CLI from GitHub: github:google-gemini/gemini-cli#${VERSION_INPUT}"
@@ -263,7 +268,7 @@ runs:
           git checkout "${VERSION_INPUT}"
           npm install
           npm run bundle
-          npm install --silent --no-audit --prefer-offline --global .
+          npm install --silent --no-audit --prefer-offline --global --prefix "${GEMINI_CLI_INSTALL_PREFIX}" .
         fi
         echo "Verifying installation:"
         if command -v gemini >/dev/null 2>&1; then


### PR DESCRIPTION
Addresses #332.

This changes the Gemini CLI install step to use a runner-temp install prefix instead of relying on the system npm global prefix. On locked-down self-hosted runners, the default global prefix can be unwritable, which can cause the `npm install --global @google/gemini-cli@latest` step to fail before `gemini` is available on `PATH`.

Changes:
- Create a temporary install prefix under `${RUNNER_TEMP:-${HOME}}/gemini-cli-install`.
- Add the install prefix `bin` directory to the current step `PATH` and to `GITHUB_PATH` for later steps.
- Use `npm install --global --prefix "${GEMINI_CLI_INSTALL_PREFIX}"` for npm installs.
- Point `PNPM_HOME` at the same bin directory for the pnpm global install path.
- Apply the same temp-prefix behavior when installing a built Gemini CLI checkout from a branch/tag/commit.

Validation:
- `ruby -e "require 'yaml'; YAML.load_file('action.yml')"`
- `npm install` completed. Local Node `v22.11.0` emitted an engine warning for Vite requiring `^20.19.0 || >=22.12.0`, but install completed.
- Local npm-prefix install simulation:
  - created a temp `gemini-cli-install` prefix
  - installed `@google/gemini-cli@latest` with `--global --prefix`
  - `command -v gemini` resolved to the temp prefix
  - `gemini --version` returned `0.45.2`
- `npm run format:check`
- `git diff --check`
