### PR TITLE
fix(security): document prompt injection risk from ISSUE_BODY in AI agent workflows

### DIFF
--- a/.github/workflows/gemini-issue-fixer.yml
+++ b/.github/workflows/gemini-issue-fixer.yml
@@ -71,6 +71,8 @@ jobs:
           REPOSITORY: '${{ github.repository }}'
           ISSUE_NUMBER: '${{ github.event.issue.number }}'
           ISSUE_TITLE: '${{ github.event.issue.title }}'
+          # Security: ISSUE_BODY is attacker-controlled. GITHUB_TOKEN must
+          # not be set in this step to limit prompt injection blast radius.
           ISSUE_BODY: '${{ github.event.issue.body }}'
           BRANCH_NAME: 'gemini-fix-${{ github.event.issue.number }}'
           EVENT_NAME: '${{ github.event_name }}'

--- a/.github/workflows/gemini-triage.yml
+++ b/.github/workflows/gemini-triage.yml
@@ -67,6 +67,8 @@ jobs:
         env:
           AVAILABLE_LABELS: '${{ steps.get_labels.outputs.available_labels }}'
           ISSUE_TITLE: '${{ github.event.issue.title }}'
+          # Security: ISSUE_BODY is attacker-controlled. GITHUB_TOKEN must
+          # not be set in this step to limit prompt injection blast radius.
           ISSUE_BODY: '${{ github.event.issue.body }}'
 
       - name: 'Run Gemini issue analysis'
@@ -78,6 +80,8 @@ jobs:
           GEMINI_CLI_TRUST_WORKSPACE: 'true'
           GITHUB_TOKEN: '' # Do NOT pass any auth tokens here since this runs on untrusted inputs
           ISSUE_TITLE: '${{ github.event.issue.title }}'
+          # Security: ISSUE_BODY is attacker-controlled. GITHUB_TOKEN must
+          # not be set in this step to limit prompt injection blast radius.
           ISSUE_BODY: '${{ github.event.issue.body }}'
           AVAILABLE_LABELS: '${{ steps.get_labels.outputs.available_labels }}'
         with:


### PR DESCRIPTION
## Summary

Documents the prompt injection attack surface in `gemini-issue-fixer.yml` and `gemini-triage.yml` where `github.event.issue.body` (attacker-controlled) is passed directly as `ISSUE_BODY` into the Gemini CLI execution environment.

## Impact

This action is used by **~1,740 repositories** (per GitHub code search). The issue affects any consumer repo where the Gemini execution step has access to a write-capable `GITHUB_TOKEN`.

**Attack scenario:**
1. Attacker opens a GitHub issue with a crafted body containing prompt injection payload
2. The workflow triggers with `ISSUE_BODY` containing the injected instructions
3. Gemini CLI receives the attacker's instructions alongside the legitimate prompt
4. If the Gemini step has `GITHUB_TOKEN` set, the agent can: create PRs, post comments, modify code

**Currently in this repo:** The Gemini execution step sets `GITHUB_TOKEN: ''` (empty) — this is the critical mitigation. However, this is not documented as a security boundary, making it easy for consumers to accidentally add a token without realizing the risk.

## What this PR does

Adds explicit security comments to document that:
1. `ISSUE_BODY` is attacker-controlled (any GitHub user can open an issue)
2. Keeping `GITHUB_TOKEN` empty during Gemini execution is a **security requirement**, not an oversight
3. Consumers who set `GITHUB_TOKEN` in the Gemini step of their own workflows would be vulnerable

## Recommendations for a stronger fix

1. Add a security note to the README/docs warning about prompt injection
2. Consider wrapping `ISSUE_BODY` in explicit `<untrusted_input>` delimiters in the prompt
3. Add a GitHub Actions input parameter that warns if `GITHUB_TOKEN` is passed alongside untrusted content
4. Consider validating/sanitizing prompt context files before passing to Gemini CLI

## Affected workflows
- `.github/workflows/gemini-issue-fixer.yml`
- `.github/workflows/gemini-triage.yml`