### PR TITLE
refactor: restrict Token Creator role to self-impersonation in setup script

### DIFF
--- a/scripts/setup_workload_identity.sh
+++ b/scripts/setup_workload_identity.sh
@@ -347,13 +347,13 @@ gcloud projects add-iam-policy-binding "${GOOGLE_CLOUD_PROJECT}" \
     --member="serviceAccount:${SERVICE_ACCOUNT_EMAIL}" \
     --condition=None
 
-# Allow the service account to generate an access tokens
-print_info "Granting 'Service Account Token Creator' role to Service Account..."
+# Allow the service account to generate an access tokens (self-impersonation only)
+print_info "Granting 'Service Account Token Creator' role to Service Account (self-impersonation)..."
 
-gcloud projects add-iam-policy-binding "${GOOGLE_CLOUD_PROJECT}" \
+gcloud iam service-accounts add-iam-policy-binding "${SERVICE_ACCOUNT_EMAIL}" \
+    --project="${GOOGLE_CLOUD_PROJECT}" \
     --role="roles/iam.serviceAccountTokenCreator" \
-    --member="serviceAccount:${SERVICE_ACCOUNT_EMAIL}" \
-    --condition=None
+    --member="serviceAccount:${SERVICE_ACCOUNT_EMAIL}"
 
 # Grant logging permissions to the service account
 print_info "Granting 'Logging Writer' role to Service Account..."


### PR DESCRIPTION
### Description
This PR updates the `setup_workload_identity.sh` script to align the service account configuration with the principle of least privilege.

### Why
The script previously granted the `Service Account Token Creator` role (`roles/iam.serviceAccountTokenCreator`) to the triage service account at the project level. This project-wide grant is broader than necessary for the CLI's token management needs. Restricting this role to the service account resource itself (allowing self-impersonation) is sufficient and follows Google Cloud best practices.

### Changes
*   **IAM:** Modified the `gcloud` command in `setup_workload_identity.sh` to use `gcloud iam service-accounts add-iam-policy-binding` targeting the specific service account resource, rather than `gcloud projects add-iam-policy-binding`.

