### PR TITLE
chore(deps): Pin actions to a commit sha

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -218,7 +218,7 @@ runs:
       if: |-
         ${{ inputs.gcp_workload_identity_provider != '' }}
       id: 'auth'
-      uses: 'google-github-actions/auth@v3' # ratchet:exclude
+      uses: 'google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093' # ratchet:google-github-actions/auth@v3
       with:
         project_id: '${{ inputs.gcp_project_id }}'
         workload_identity_provider: '${{ inputs.gcp_workload_identity_provider }}'
@@ -432,7 +432,7 @@ runs:
     - name: 'Upload Gemini CLI outputs'
       if: |-
         ${{ inputs.upload_artifacts == 'true' }}
-      uses: 'actions/upload-artifact@v6' # ratchet:exclude
+      uses: 'actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f' # ratchet:actions/upload-artifact@v6
       with:
         name: 'gemini-output'
         path: 'gemini-artifacts/'


### PR DESCRIPTION
<!--
Thank you for proposing a pull request! Please note that SOME TESTS WILL
LIKELY FAIL due to how GitHub exposes secrets in Pull Requests from forks.
Someone from the team will review your Pull Request and respond.

Please describe your change and any implementation details below.
-->

We are relying on this action [here](https://github.com/DataDog/code-review-action) and are enforcing actions pinned to commit sha in our repositories. 
With actions pinned to a tag, we cannot use the gemini client, see [this workflow execution](https://github.com/DataDog/datadog-agent/actions/runs/28447474045/job/84330396079?pr=52774)

I kept conservative ratchet for minimal impact, I had a quick look at the git history and I don't see a strict reason not to pin this on the most recent versions, but I let you tell me what you prefer.

Thanks in advance for any review/comment
